### PR TITLE
Erinbecker patch1

### DIFF
--- a/topic_folders/instructor_training/trainers_guide.md
+++ b/topic_folders/instructor_training/trainers_guide.md
@@ -4,6 +4,32 @@
 As of May 2017, the Trainers group adopted a 
 [Trainer Agreement][trainer-agreement] outlining Trainer duties. Only active Trainers are voting members of the Trainer community. An inactive Trainer may re-activate their Trainer status at any time by resuming Trainer activities.
 
+##### Trainer Agreement
+I agree to follow the [Code of Conduct](http://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) in all communications and interactions 
+with the Carpentry community and to [promptly report any violations of the CoC](http://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#reporting-guidelines)
+that I become aware of.
+
+I understand that the secondary learning outcomes of workshops are as important as their stated goals. I will:  
+- Communicate Carpentry community values to trainees and model that behaviour myself in how I teach  
+- Provide a welcoming and supporting environment for trainees  
+- Model our “show, don’t tell” policy in instructor training  
+- Connect the principles used in Carpentry workshops with other teaching contexts  
+
+I understand that it is important to keep up to date and in touch with the Trainer community so that my teaching will
+reflect current practices and curriculum. Therefore, to be an active Trainer, I agree to:  
+- Teach at least two instructor training events per year  
+- Host on average four teaching demonstration per year  (1 per quarter)  
+- Regularly attend Trainer Discussion and Business meetings when possible and read meeting minutes/notes when I am not able to attend  
+- Read emails sent to the Trainer listserv  
+- Keep up-to-date with the instructor training curriculum  
+- Teach a curriculum that fulfills all of the current requirements for instructor certification  
+- Provide feedback to other trainers and Carpentries staff about training events to help continue developing our offerings  
+
+I understand that Carpentry staff need an accurate understanding of Trainer availability in order to plan instructor training 
+events. If at any point I am no longer able to serve as a Trainer, I will let Carpentry staff know. I understand that only active
+Trainers are voting members of the Trainer community, but that I will be able to re-activate my Trainer status at any time by resuming
+Trainer activities.  
+
 #### Becoming a Trainer
 The Trainers group periodically accepts new members via application. New Trainers undergo an eight-week training program outlined [in this document][trainer-process] and agree to the [Trainer Agreement][trainer-agreement].
 
@@ -17,7 +43,7 @@ The Trainers group meets regularly. We have two types of meetings - business mee
 3. Member sites will sign up for available dates. The Program Manager will let you know which sites you will be teaching as they sign up.
 4. If no member site signs up one month before the event, the event will become an open instructor training or be cancelled, depending on need.
 
-A calendar for how signups are scheduled is [here](/instructor_training/scheduling_training_events.html).
+A calendar for upcoming instructor training events is [here](http://carpentries.github.io/instructor-training/training_calendar/).
 
 #### Running an Instructor Training Event (General)
 
@@ -146,10 +172,10 @@ Any episode other than those listed below should make an okay starting point for
    * OpenRefine - anything after [Layout of OpenRefine, Rows vs Records](https://data-lessons.github.io/library-openrefine/03-working-with-data/) - dependencies
 
 
-[trainer-agreement]: https://github.com/carpentries/policies/blob/master/trainer-agreement.md
-[trainer-process]: https://docs.google.com/document/d/14Zi_W9uk1wua2v3zy8um6oMCnvO41Qfo1KwStCA-hos/edit
+[trainer-agreement]: http://docs.carpentries.org/topic_folders/instructor_training/trainers_guide.html#trainer-agreement
+[trainer-process]: http://docs.carpentries.org/topic_folders/instructor_training/trainers_training.html
 [trainer-pad]: http://pad.software-carpentry.org/trainers
-[community-calendar]: http://pad.software-carpentry.org/trainers
+[community-calendar]: https://software-carpentry.org/join/#community-events
 [trainer-minutes]: https://github.com/carpentries/trainers/tree/master/minutes
 [etherpad-template]: http://pad.software-carpentry.org/ttt-template
 [training-template]: https://github.com/swcarpentry/training-template

--- a/topic_folders/policies/code-of-conduct.md
+++ b/topic_folders/policies/code-of-conduct.md
@@ -182,7 +182,7 @@ The Policy committee will never publicly discuss the details of the issue; all p
 
 At the end of every quarter, the executive council will publish an aggregated count of the incidents the Policy Subcommittee dealt with, indicating how many reports it received, how many incidents it investigated independently, how many times it acted unilaterally, and for each of these which under part of the Code of Conduct the incident was classified.  
 
-**Conflicts of Interest**  
+**Conflicts of Interest**  c
 In the event of any conflict of interest (a committee member, their family member, or someone with whom the committee member has a close academic or employment relationship is involved in a complaint), the committee member must immediately notify the other members, and recuse themselves if necessary.  
 
 This document is adapted from guidelines written by the [Django Project](https://www.djangoproject.com/conduct/enforcement-manual/), which was itself based on the [Ada Initiative](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports) template and the [PyCon 2013 Procedure for Handling Harassment Incidents](https://us.pycon.org/2013/about/code-of-conduct/harassment-incidents/). Contributors to this document: Adam Obeng, Aleksandra Pawlik, Bill Mills, Carol Willing, Erin Becker, Hilmar Lapp, Kara Woo, Karin Lagesen, Pauline Barmby, Sheila Miguez, Simon Waldman, Tracy Teal.

--- a/topic_folders/policies/code-of-conduct.md
+++ b/topic_folders/policies/code-of-conduct.md
@@ -182,7 +182,7 @@ The Policy committee will never publicly discuss the details of the issue; all p
 
 At the end of every quarter, the executive council will publish an aggregated count of the incidents the Policy Subcommittee dealt with, indicating how many reports it received, how many incidents it investigated independently, how many times it acted unilaterally, and for each of these which under part of the Code of Conduct the incident was classified.  
 
-**Conflicts of Interest**  c
+**Conflicts of Interest** 
 In the event of any conflict of interest (a committee member, their family member, or someone with whom the committee member has a close academic or employment relationship is involved in a complaint), the committee member must immediately notify the other members, and recuse themselves if necessary.  
 
 This document is adapted from guidelines written by the [Django Project](https://www.djangoproject.com/conduct/enforcement-manual/), which was itself based on the [Ada Initiative](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports) template and the [PyCon 2013 Procedure for Handling Harassment Incidents](https://us.pycon.org/2013/about/code-of-conduct/harassment-incidents/). Contributors to this document: Adam Obeng, Aleksandra Pawlik, Bill Mills, Carol Willing, Erin Becker, Hilmar Lapp, Kara Woo, Karin Lagesen, Pauline Barmby, Sheila Miguez, Simon Waldman, Tracy Teal.


### PR DESCRIPTION
- Moved Trainers agreement from link to external policy repo to text within the handbook itself. 
- fixed link to training calendar
- fixed link to trainer training process
- fixed link to community calendar