### PR TITLE
add skill examples in email template advertising workshop

### DIFF
--- a/topic_folders/workshop_administration/email_templates.md
+++ b/topic_folders/workshop_administration/email_templates.md
@@ -163,7 +163,11 @@ This workshop is focused on [ Carpentry/domain ]. The curriculum will include:
 - [names of lessons]
 - [names of lessons]
 
-The target audience is learners who have little to no prior computational experience, and the instructors put a priority on creating a friendly environment to empower researchers and enable data-driven discovery. Even those with some experience will benefit, as the goal is to teach not only how to do analyses, but how to manage the process to make it as automated and reproducible as possible.
+The target audience is learners who have little to no prior computational experience, and the instructors put a priority on creating a friendly environment to empower researchers and enable data-driven discovery. Even those with some experience will benefit, as the goal is to teach not only how to do analyses, but how to manage the process to make it as automated and reproducible as possible. For instance, after attending this workshop you will be able to:
+
+- [skill 1]
+- [skill 2]
+- [skill 3]
 
 Space is limited and it will likely fill quickly. [ Add sentence about whether workshop is free or if there is a fee. ]. Here is a registration link [ link to your registration page ], and the workshop webpage [ link to your workshop webpage ] for more information. Questions? Send email to [ email contact ].
 


### PR DESCRIPTION
Something that has come up regularly in discussions is that we should list some of the skills learners would acquire when attending our workshops. It will help people decide whether the level is appropriate for them. 

Maybe we can provide some examples of sentences based on learning objectives. @kariljordan what do you think?

