### PR TITLE
Include date in Subject Line

### DIFF
--- a/topic_folders/workshop_administration/email_templates.md
+++ b/topic_folders/workshop_administration/email_templates.md
@@ -24,7 +24,7 @@ Best,
 
 ##### Host and instructor introductions
 
-Subject: Carpentries workshop at [ site_name ] - Making introductions
+Subject: Carpentries workshop at [ site_name ] [Date of Workshop] - Making introductions
 
 Hi everyone,
 


### PR DESCRIPTION
Helps when having to go back and find email threads. Especially if certain sites are having multiple workshops. 