### PR TITLE
remove redundant info, fix links

### DIFF
--- a/topic_folders/mentoring/discussion_session.md
+++ b/topic_folders/mentoring/discussion_session.md
@@ -1,12 +1,12 @@
-## Discussion Sessions
+## Instructor Discussion Sessions
 
-This document describes how instructor discussion sessions are organized and conducted.  Checklists for the hosts and discussion organizer are [here](#checklists-instructor-discussion-sessions).  
+The mentoring committee’s main duty is to lead and organize the instructor discussion sessions. This document describes how instructor discussion sessions are organized and conducted.  Checklists for the hosts and discussion organizer are [here](#checklists-instructor-discussion-sessions).  
 
 ### Terminology
 
 -   **Instructor discussion session**: an online meeting where instructors share experiences from teaching and obtain information while preparing to teach.
 -   **Discussion Session Host**: member of the Carpentries community who facilitates a discussion session.
--   **Discussion Session Coordinator**: a volunteer from the Mentoring Subcommittee whose responsiblities include updating the scheduling etherpad and emailing invitations to instructors. Further information about the role, including relevant checklists and email templates, can be found on the [Mentoring Subcommittee repository](https://github.com/carpentries/mentoring/blob/master/roles/discussion-coordinators.md).
+-   **Discussion Session Coordinator**: a volunteer from the Mentoring Subcommittee whose responsiblities include updating the scheduling Etherpad and emailing invitations to instructors. For more information about this role, see the [role description](../mentoring-subcommittee-roles/#discussion-session-coordinators).
 
 ### Motivation
 
@@ -16,7 +16,7 @@ This document describes how instructor discussion sessions are organized and con
 
 1. The Carpentries are continuing to increase the number of instructors and develop new lessons. New instructors would like to hear from experienced teachers who have recently taught to help prepare for upcoming workshops.
 
-### Who can host?
+### Who Can Host?
 
 Hosting discussion sessions is a great way to meet more people in the Carpentries community, to get to know the organisation better, to learn from the experiences of others and to share your own knowledge and experience with an even greater number of people.
 
@@ -24,11 +24,35 @@ Any instructor with experience of organising/teaching workshops and a good knowl
 
 A great way to get into hosting these sessions is to first attend as an observer or co-host. An experienced host will be happy to talk you through it, and may return the favour when you host for the first time, so that you don't have to "fly solo" in your first session. 
 
+### Signing Up to Host/Co-Host Discussion
+
+* Identify a discussion session you’d like to host OR co-host on the Instructor Discussion etherpad: http://pad.software-carpentry.org/instructor-discussion
+* Type your name in the “Host” or “Co-host/notetaker” slot for the session you’ve chosen (email next to your name optional, however, if you provide your e-mail it may help facilitate communication before and after the discussion)
+* Add the time/date details of the discussion session you’re going to be a “Host” or "Co-host/notetaker" for on your calendar
+* Copying the etherpad link in your calendar event is a good idea, too!
+
+#### Host Expectations
+* Primary role is to facilitate the instructor discussion sessions using the agenda at the bottom of the etherpad.
+* While it’s the co-hosts main responsibility to take notes, please take notes in the etherpad when the co-host/notetaker is speaking.
+* Maintaining focus on the main goal of the session, which is to share ideas, support each other, and keep instructors excited about teaching.
+* Ensuring instructors teaching in the near future have urgent questions or concerns addressed.
+* Collecting feedback from instructors who have recently taught.
+* Engaging newly trained instructors and evaluating their participation using a subset of questions described in the checkout procedure here: http://swcarpentry.github.io/instructor-training/checkout/.
+* Encouraging attendees to create issues or pull requests to correct problems.
+
+#### Co-Host Expectations
+* Primary role is to assist with note-taking while the Host leads the discussion
+* Take accurate notes of discussion on the etherpad
+* At the beginning of the callI, introduce yourself as the co-host/notetaker
+* Co-hosts/notetakers do not have to be the very active in the conversation
+* If a co-host/notetaker does want to chime in, it is welcome!
+* **NOTE:** if the session is mostly instructor checkouts, it is highly recommended that you, as the co-host, contribute to the discussion with your experience helping out with workshops.
+
 ### Checklists - Instructor Discussion Sessions
 
-Discussion sessions are organized and conducted through [this etherpad](http://pad.software-carpentry.org/instructor-discussion)
+Discussion sessions are organized and conducted through [this Etherpad](http://pad.software-carpentry.org/instructor-discussion).
 
-### Before the Discussion Session
+#### Before the Discussion Session (Discussion Session Coordinator)
 
 The Mentoring Subcommittee is responsible for organizing the instructor discussion sessions so that
 
@@ -38,16 +62,15 @@ The Mentoring Subcommittee is responsible for organizing the instructor discussi
 
 -   each session has at least one host (preferably two) to conduct the discussion.
 
-
 The Discussion Session Coordinator is responsible for scheduling the events and inviting instructors who are about to teach and who have recently taught.
 
-Meeting scheduling will be coordinated via [etherpad](http://pad.software-carpentry.org/instructor-discussion).
+Meeting scheduling will be coordinated via [Etherpad](http://pad.software-carpentry.org/instructor-discussion).
 
 The dates of instructor discussion sessions are also listed in the Carpentries [community calendar](https://calendar.google.com/calendar/embed?src=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com).
 
 1.  Invitations are tracked through two spreadsheets - one for instructors doing a [post-workshop debriefs](https://docs.google.com/spreadsheets/d/1OZuaulmSVcekQcFlfWc6cK_8odm64pMqGnEMl3hSPHU/edit#gid=0), sent weekly, and one for instructors doing a [pre-workshop discussion session](https://docs.google.com/spreadsheets/d/1C-R24LRURYx5-PjeW45vvZtPRI7LaQFg8tzixkkq49o/edit#gid=1948936411), sent every other week.
 
-1. Use the [email templates](email_templates.html) for the respective discussion invitation. Replace the variables in brackets with the appropriate information for that session.
+1. Use the [email templates](../email_templates) for the respective discussion invitation. Replace the variables in brackets with the appropriate information for that session.
 
 1. Log in to [AMY](https://amy.software-carpentry.org/account/login/?next=/workshops/log/).  Go to the [reporting section](../workshop_administration/amy_manual.html#reports) to the "List of instructors by time period" section. Filter for instructors in the relevant time period. Download this list as csv to easily read each instructor's email address.
 
@@ -55,10 +78,9 @@ The dates of instructor discussion sessions are also listed in the Carpentries [
 
 1.  Email `team@carpentries.org` with any instructors with missing or invalid emails.
 
+#### Leading the Discussion (Host and Co-host)
 
-### Leading the Discussion
-
-Meetings will be hosted on a Zoom videoconference, linked via the [instructor discussion etherpad](http://pad.software-carpentry.org/instructor-discussion).
+Meetings will be hosted on a Zoom videoconference, linked via the [instructor discussion Etherpad](http://pad.software-carpentry.org/instructor-discussion).
 
 Each instructor discussion session session must have at least one host (although two hosts are preferred). Any experienced instructor is welcome to host, but hosts are encouraged to join the mentoring subcommittee. 
 
@@ -92,34 +114,18 @@ The agenda should be similar to the following:
     - For big problems or concerns, start an issue on GitHub in the appropriate lesson or add to Google Doc of commonly mentioned concerns
     - For small typos, submit pull request to appropriate lesson
 
-(A copy of this agenda is kept at the bottom of the instructor discussion etherpad.)
+(A copy of this agenda is kept at the bottom of the instructor discussion Etherpad.)
 
 Based on discussion among the mentoring committee, temporary questions may be added to the agenda for a month of sessions, in order to collect data on specific issues.  
 
 - Take notes
 
-The **host** is responsible for: 
-
-- hosting the meeting and facilitating discussion using the agenda described above. 
-
-- maintaining focus on the main goal of the session, which is to share ideas and keep instructors excited about teaching.
-
-- ensuring instructors teaching in the near future have urgent questions or concerns addressed.
-
-- collecting feedback from instructors who have recently taught.
-
-- engaging newly trained instructors and evaluating their participation using a subset of 
-questions described in the checkout procedure.
-
-- encouraging attendees to create issues or pull requests to correct problems.
-
 > If there are more than 5 workshops represented by attendees, the discussion session should be split into two groups, to make sure everyone has enough time to share.  When dividing attendees into two groups, try to balance the number of people who are de-briefing, who are there for pre-workshop help, and who are instructor trainees.  If there are exactly 5 workshops represented, it is at the discretion of the host whether to split the group.  
 
-
-### After the discussion
-- Archive the etherpad by clicking on the star in the top right corner.  
-- **Fill out the [host questionnaire](https://goo.gl/forms/iXkMQABmO6HROfCy1)**
-    - *Note:* Please copy the list of attendees (including all attendees but removing no-shows) and paste it into question 7 of the questionnaire. 
+#### After the discussion
+- Archive the Etherpad by clicking on the star in the top right corner.  
+- Fill out the [host questionnaire](https://goo.gl/forms/iXkMQABmO6HROfCy1)
+    - Note: Please copy the list of attendees (including all attendees but removing no-shows) and paste it into question 7 of the questionnaire. 
     - This questionnaire will automatically send an email to the mentoring co-chairs and to checkout@carpentries.org.
 - Clear the information from your session (date/time, attendees, notes) from the etherpad. 
 - (Optional) write a blog post about interesting points that came up in discussion; see 

--- a/topic_folders/mentoring/mentoring-groups-roles.md
+++ b/topic_folders/mentoring/mentoring-groups-roles.md
@@ -26,18 +26,6 @@ The join the mentoring program, email the Deputy Director of Assessment, Kari L 
 
 [Program Outline](https://github.com/datacarpentry/mentoring-program/blob/master/program-outline.md)
 
-### Mentoring Coordinator
-
-#### Responsibilities
-
-- Recruit mentors and mentees for the Mentoring Program.  
-- Pair Mentors and Mentees based on responses to Google form surveys.  
-- Set up virtual meeting rooms and Etherpads for each mentoring team.  
-- Send email introductions for each mentoring team.  
-- Follow up with each mentoring team on a monthly basis and ask if there's anything you can do to help.  
-- Keep track of program completion rates to assess success.  
-- Get feedback from Mentors and Mentees about program.  
-
 ### Mentors
 
 #### Responsibilities
@@ -66,3 +54,15 @@ To join the mentoring program, email the Deputy Director of Assessment at karilj
 #### Resources and Checklists
 
 [Program Outline](https://github.com/datacarpentry/mentoring-program/blob/master/program-outline.md)
+
+### Mentoring Coordinator
+
+#### Responsibilities
+
+- Recruit mentors and mentees for the Mentoring Program.  
+- Pair Mentors and Mentees based on responses to Google form surveys.  
+- Set up virtual meeting rooms and Etherpads for each mentoring team.  
+- Send email introductions for each mentoring team.  
+- Follow up with each mentoring team on a monthly basis and ask if there's anything you can do to help.  
+- Keep track of program completion rates to assess success.  
+- Get feedback from Mentors and Mentees about program.  

--- a/topic_folders/mentoring/mentoring-groups.md
+++ b/topic_folders/mentoring/mentoring-groups.md
@@ -105,5 +105,5 @@ At minimum, in each session we recommend that you identify goals to be achieved,
 + Discuss current challenges around your mentoring topic questions. 
 + Set [SMART Goals](http://www.hr.virginia.edu/uploads/documents/media/Writing_SMART_Goals.pdf) to surmount the groups challenges.
 
-#### Contact Information
+### Contact Information
 If you have questions about the mentoring groups please contact [Kari L. Jordan](mailto:kariljordan@carpentries.org?subject=Mentoring%20Groups).

--- a/topic_folders/mentoring/mentoring-subcommittee-roles.md
+++ b/topic_folders/mentoring/mentoring-subcommittee-roles.md
@@ -178,7 +178,7 @@ Our main checklist for actually leading discussions is [here](../checklists-disc
 
 [host-mailing-list]: https://groups.google.com/a/carpentries.org/forum/#!forum/discussion-hosts
 
-### Committee Liaison(s)
+### Committee Liaisons
 
 The Mentoring Subcommittee benefits from regular updates from other committees within the organisation.
 Currently, the committee receives updates from the Steering and Training Committees.

--- a/topic_folders/mentoring/mentoring-subcommittee.md
+++ b/topic_folders/mentoring/mentoring-subcommittee.md
@@ -1,37 +1,24 @@
 ## Mentoring Subcommittee
 
-### Onboarding: Mentoring Committee
-
-#### Topics Covered
-* [Mission Statement](#mission-statement)
-* [What does the mentoring committee do?](#what-does-the-mentoring-committee-do)
-* [Committee member roles](#mentoring-roles)
-* [Joining the conversation](#joining-the-conversation)
-* [Mentoring Committee Meetings](#mentoring-committee-meetings)
-* [Attending a mentoring committee meeting](#attending-a-mentoring-committee-meeting)
-* [Instructor Discussion Sessions](#instructor-discussion-sessions)
-* [Instructor Discussions: Host and Co-Host Expectations](#host-expectations)
+### Onboarding
 
 #### Mission Statement
 Established in 2015 to develop and maintain a mentoring program, the program supports instructors as they progress through training, teaching, curriculum development, and other community-related activities. We help promote community-building and networking, by providing virtual spaces where instructors from all over the world can share teaching success stories and discuss teaching strategies.
 
-#### What does the mentoring committee do?
+#### What We Do
 * Meets as a committee once a month.
 * Hosts weekly discussion sessions.
 
 #### Committee Member Roles
 
-- [Co-Chairs](https://github.com/carpentries/mentoring/blob/master/roles/co-chairs.md)
-- [Discussion Coordinators](https://github.com/carpentries/mentoring/blob/master/roles/discussion-coordinators.md)
-- [Discussion Hosts](https://github.com/carpentries/mentoring/blob/master/roles/discussion-hosts.md)
-- [Committee Liaison](https://github.com/carpentries/mentoring/blob/master/roles/committee-liaison.md)
-- [Staff Liaison](https://github.com/carpentries/mentoring/blob/master/roles/staff-liaison.md)
-- [Mentees](https://github.com/carpentries/mentoring/blob/master/roles/mentees.md)
-- [Mentoring Coordinator](https://github.com/carpentries/mentoring/blob/master/roles/mentoring-coordinator.md)
-- [Mentors](https://github.com/carpentries/mentoring/blob/master/roles/mentors.md)
-- [Secretary](https://github.com/carpentries/mentoring/blob/master/roles/secretary.md)
+- [Co-Chairs](../mentoring-subcommittee-roles/#co-chairs)
+- [Discussion Coordinators](../mentoring-subcommittee-roles/#discussion-session-coordinators)
+- [Discussion Hosts](../mentoring-subcommittee-roles/#discussion-hosts)
+- [Committee Liaison](../mentoring-subcommittee-roles/#committee-liaisons)
+- [Staff Liaison](../mentoring-subcommittee-roles/#staff-liaison)
+- [Secretary](../mentoring-subcommittee-roles/#secretary)
 
-#### Monthly meeting topics
+#### Monthly Meeting Topics
 * Instructor discussion sessions:
 * How are the instructor discussions going?
 * Formulate and update agenda items for the instructor discussions.
@@ -43,133 +30,37 @@ Established in 2015 to develop and maintain a mentoring program, the program sup
 * How can we support instructors in parts of the world where there is not currently a local supportive community? How can our community build/grow in places in which the Carpentries may or may not currently exist?
 * How can our community be more inclusive?
 
-#### Joining the conversation
+#### Join the Conversation
 * Mailing list for the mentoring committee: mentoring@lists.software-carpentry.org
 * [Mailing list administration](http://lists.software-carpentry.org/listinfo/mentoring).  Contact [team@carpentries.org](mailto:team@carptentries.org) if you need admin access.
-* [Mentoring etherpad](http://pad.software-carpentry.org/scf-mentoring)
+* [Mentoring Etherpad](http://pad.software-carpentry.org/scf-mentoring)
 * Meeting Minutes: [https://github.com/carpentries/mentoring/tree/master/minutes](https://github.com/carpentries/mentoring/tree/master/minutes)
 * [Community Calendar](https://calendar.google.com/calendar/embed?src=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com)
 
 #### Mentoring Committee Meetings
-* Committee meetings are organized on the [subcommittee etherpad](http://pad.software-carpentry.org/scf-mentoring).
+* Committee meetings are organized on the [subcommittee Etherpad](http://pad.software-carpentry.org/scf-mentoring).
 * Meetings are once a month, at two times to accommodate time zones, usually on a Monday or Tuesday. The meetings are organized and announced 1-2 weeks in advance.
-* Some common questions:
+##### Some common questions:
 * Who can attend mentoring committee meetings?
-* Anyone in the Carpentries community is welcome to attend! If you have even a slight interest in getting involved, we strongly encourage you to attend! You can see a list of current members of the committee on the [README](https://github.com/carpentries/mentoring/blob/master/README.md) of this repository.
+Anyone in the Carpentries community is welcome to attend! If you have even a slight interest in getting involved, we strongly encourage you to attend! You can see a list of current members of the committee on the [README](https://github.com/carpentries/mentoring/blob/master/README.md) of our GitHub repository.
 * Why join?
-* Mentoring committee meetings are a great opportunity to share ideas and support each other, to engage and empower all members of the Carpentries community, and to help grow, build, and be part of our community.
+Mentoring committee meetings are a great opportunity to share ideas and support each other, to engage and empower all members of the Carpentries community, and to help grow, build, and be part of our community.
 
 ##### Attending a mentoring committee meeting
-* **Before the meeting**
+###### Before the meeting
 * Join the [mailing list](http://lists.software-carpentry.org/listinfo/mentoring) to get the most updated information about mentoring committee activities and meetings.
 * Check out the etherpad for details on the next committee meeting and join by adding your name in your preferred time at the top of the [etherpad](http://pad.software-carpentry.org/scf-mentoring).
 * Look out for the email from the chairs to the mentoring committee email list and read/think about any documents/topics they may ask
 * Encourage members of the community to join us
 * Tweet/e-mail individual people and encourage them to join in too!
 * If you are able to join the meeting, sign your name as an attendee at the top of the etherpad and tell us whether you will join for the 1st or 2nd meeting (that way we know to look out for you!)
-* **During the meeting**
+
+###### During the meeting
 * Join the videocall, linked to in the [etherpad](http://pad.software-carpentry.org/scf-mentoring).
 * Participate! If you are new to the committee we strongly encourage you to share your ideas/opinions! Your experience is extremely valuable to us.
-* If the secretary is gone - please help out by taking notes in the etherpad!
-* **After the meeting**
+* If the secretary is gone - please help out by taking notes in the Etherpad!
+
+###### After the meeting
 
 * The secretary will post minutes on the [GitHub repo](https://github.com/carpentries/mentoring/tree/master/minutes)
 
----
-### Instructor Discussion Sessions
-
-The mentoring committee’s main duty is to lead and organize the instructor discussion sessions. The instructor discussion etherpad: http://pad.software-carpentry.org/instructor-discussion
-* Each month has at least eight discussion sessions
-* Instructors are notified at least one week in advance of their workshop and can sign up for their preferred time
-* Each session has at least one host and one co-host/notetaker to conduct the discussion:
-* **Host:** The host is the leader of the discussion session and will be the main discussion guide. The host is expected to share their experiences being an instructor and to keep the discussion on track.
-* Please take notes in the etherpad when the co-host/notetaker is speaking.
-* Email co-host/notetaker to see if they would like any advice/guidance - especially if it is their first time co-hosting/notetaking or you don’t know your co-host/notetaker
-* **Co-host/note taker:** The co-hosts main role is to take notes on the discussion session and to share their experience as an instructor when they can. It is especially important for the co-host to step in with their experience when there are many instructor training check-outs in the session. Otherwise, the co-host can mainly take notes.
-* Please sign up to host or co-host a discussion session! :)
-* If you notice that no one is signed up to be host, it can be helpful if you email the listserv asking for people to sign up to host/co-host.
-* Meeting scheduling will be coordinated via etherpad.
-* If you’re interested in finding out more about how these sessions work, you’re welcome to attend as a silent observer/listener. Sign up on the etherpad and let the host know that you would like to observe their session.
-* The dates of instructor discussion sessions are also listed in the SCF community calendar,  https://calendar.google.com/calendar/embed?src=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com.
-
-#### Signing Up to Host/Co-Host Discussion
-
-* Identify a discussion session you’d like to host OR co-host on the Instructor Discussion etherpad: http://pad.software-carpentry.org/instructor-discussion
-* Type your name in the “Host” or “Co-host/notetaker” slot for the session you’ve chosen (email next to your name optional, however, if you provide your e-mail it may help facilitate communication before and after the discussion)
-* Add the time/date details of the discussion session you’re going to be a “Host” or "Co-host/notetaker" for on your calendar
-* Copying the etherpad link in your calendar event is a good idea, too!
-
-#### Host Expectations
-**Expectations for hosts**
-* Primary role is to facilitate the instructor discussion sessions using the agenda at the bottom of the etherpad.
-* While it’s the co-hosts main responsibility to take notes, please take notes in the etherpad when the co-host/notetaker is speaking.
-* Maintaining focus on the main goal of the session, which is to share ideas, support each other, and keep instructors excited about teaching.
-* Ensuring instructors teaching in the near future have urgent questions or concerns addressed.
-* Collecting feedback from instructors who have recently taught.
-* Engaging newly trained instructors and evaluating their participation using a subset of questions described in the checkout procedure here: http://swcarpentry.github.io/instructor-training/checkout/.
-* Encouraging attendees to create issues or pull requests to correct problems.
-**Checklist for hosts in sessions**
-* Before the discussion
-* One or two days before discussion:
-* Check the Instructor Discussion etherpad to see if someone has signed up as your co-host
-* If you are not familiar with your co-host, email them to introduce yourself and see if they have any questions about the expectations for the call
-* If you are familiar with your co-host already, it is encouraged to send them a quick email acknowledging that you’ll be on the call together
-* 5 minutes before the discussion session starts:
-* Visit the Instructor Discussion etherpad a few minutes before the meeting starts
-* Check that the agenda has been copied into the etherpad
-* Joining the call:  Sign into the video conference call (around line 6 on the etherpad) by using either the:
-* Zoom app - must download the app on your device and enter meeting ID number located at top of etherpad to join the meeting
-* Zoom browser - click the meeting link at the top of the etherpad and the meeting will open in a new window in your browser
-* Join by phone if you’re unable to connect through Zoom video - you can still take notes in the etherpad and contribute to the conversation - you just won’t be able to see people and they won’t be able to see you
-**Hosting the discussion session**
-* Lead the discussion:
-* Introduce everyone at the beginning of the session (we usually introduce each other by the order in the etherpad)
-* Be sure to introduce your co-host
-* It is recommended to follow the main points of the agenda in the etherpad, but feel free to let discussion go where people want. Not all the questions need to be answered by everyone.
-* Don't feel like you have to answer all the questions as the host - draw on the other discussion participants to answer each other's questions.
-* If someone is attending as part of their training checkout, prompt them to ask a question.
-* Try to leave enough time at the end for the final agenda item.
-* Help your co-host take notes when you can
-**After the meeting discussion session**
-* **Note:** a link for the post-discussion host checklist is also located on line 15 of the instructor discussion session etherpad.
-* Email checkout@carpentries.org with the names and affiliations of instructor trainees who attended and participated in discussion. In the email you should state whether the instructor checkouts in your discussion session were engaged and could answer target questions described in the checkout procedure.
-* Copy your notes to this google doc and label with the date and which session you led.
-* These discussion notes will be used for a more formalized assessment of the lessons, mentoring, discussion sessions, and community development.
-* Archive the etherpad  by clicking the star in the top left corner. This will save a copy of the etherpad in its current state. Then, delete all the comments and change the dates to prepare the etherpad for the next session.
-* Clean the Etherpad for the next user.
-* (Optional) Write a blog post summarizing topics discussed, including (but not limited to) the following: implementation of new lessons, recurring questions about or problems while teaching, and general strategies for instructing workshops. This template can be used as the start point for the blog post.
-
-#### Co-Host Expectations
-**Expectations for co-hosts/notetakers**
-* Primary role is to assist with note-taking while the Host leads the discussion
-* Take accurate notes of discussion on the etherpad
-* At the beginning of the callI, introduce yourself as the co-host/notetaker
-* Co-hosts/notetakers do not have to be the very active in the conversation
-* If a co-host/notetaker does want to chime in, it is welcome!
-* **NOTE:** if the session is mostly instructor checkouts, it is highly recommended that you, as the co-host, contribute to the discussion with your experience helping out with workshops.
-
-**Checklist for co-hosts/notetakers in sessions:**
-* **Day of discussion session:**
-* 5 minutes before the discussion session starts:
-* Visit the Instructor Discussion etherpad a few minutes before the meeting starts
-* Under the discussion session details, copy and paste the agenda guide from the bottom of the etherpad to take notes using this outline format
-* **OR** - if you’d like to take notes without the outline format, that is fine, too - whatever you’re most comfortable with
-* Joining the call:  Sign into the video conference call (around line 6 on the etherpad) by using either the:
-* Zoom app - must download the app on your device and enter meeting ID number located at top of etherpad to join the meeting
-* Zoom browser - click the meeting link at the top of the etherpad and the meeting will open in a new window in your browser
-* Join by phone if you’re unable to connect through Zoom video - you can still take notes in the etherpad and contribute to the conversation - you just won’t be able to see people and they won’t be able to see you
-* While taking notes during the discussion:
-* It is usually easiest to take notes directly under the current discussion session details on etherpad - makes it easier for discussion participants to find toward top of etherpad
-* Try to make note of who is saying what - see examples below
-* Aaron (initials can work, too): Seeking advice about trying to ensure learners are downloading software before workshop
-* Bill: Recommends emphasizing software downloads with pre-workshop reminder emails you send out
-* Corey: If possible, encourage learners to arriving about 30 minutes early if they’re having issues downloading software - this means instructors and the workshop room need to be available then
-* Don’t worry about accuracy, the goal is noting the main discussion content
-* You can always go back and edit/clean up after the discussion!
-* If you want to contribute to the conversation but worry about typing and talking at the same time, feel free to ask the host to take over on notes while you’re talking
-* Or you can go in and fill in what you said after you’re done talking
-* When you’ve cleaned up your notes, you can let the discussion host know they are ready for archival
-* **After the discussion session**
-* See if there are other times you may gain more experience as a co-host/notetaker for future sessions.
-* After you have helped out at instructor discussions a few times, please feel welcome to sign up as a host!
-* You can even try to see if an experienced host (i.e. the host you served as co-host for) would serve as your co-host/notetaker for your first time hosting a discussion session to help ease you into the role of host


### PR DESCRIPTION
There were two separate sections for instructor discussion sessions, both with different checklists and information about host/co-host responsibilities. Deleted redundancies. 