### PR TITLE
[fix #160] rebuild all files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -a
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = CarpentriesUsersGuide
 SOURCEDIR     = .


### PR DESCRIPTION
add option that forces to build the all handbook instead of just the files that have changed.