### PR TITLE
Add role description for Trainer coordinator

### DIFF
--- a/topic_folders/instructor_training/index.rst
+++ b/topic_folders/instructor_training/index.rst
@@ -11,6 +11,7 @@ For Trainers
    duties_agreement.md
    trainers_guide.md
    trainers_training.md
+   trainer_coordinator.md
    email_templates_trainers.md
 
 For Administrators

--- a/topic_folders/instructor_training/trainer_coordinator.md
+++ b/topic_folders/instructor_training/trainer_coordinator.md
@@ -40,14 +40,14 @@ Thanks to everyone for signing up for leading teaching demonstrations in the com
 
 Here are some additional events in the next month that don’t have a Trainer listed yet. Please sign up on the Etherpad if you’re available.
 
-[list available sessions by UTC and with time and date links]
-[list available sessions by UTC and with time and date links]
+- [list available sessions by UTC and with time and date links] 
+- [list available sessions by UTC and with time and date links]
 
 As always, if you haven’t led a teaching demo before, now’s a great time to start! You can get a feel for how they are run by observing someone else’s demo session or watching a recorded [teaching demo session](https://www.youtube.com/watch?v=FFO2cq-3PPg). If you’ll be attending someone else’s training, please let the Trainer who is running the session know that you’ll be there. 
 
 If you have any questions about running a teaching demo, please contact [Erin Becker](mailto: ebecker@carpentries.org).
 
-Thank you!
+Thank you!  
 [Name]
 
 
@@ -57,11 +57,13 @@ Subject: Teaching demo cancelled - please reschedule
 Dear checkout participant,
 
 Thank you for signing up to do your teaching demonstration next week at [time in UTC from Etherpad] [time and date link]. Unfortunately, due to lack of volunteer availability, we need to cancel this session. There are still spots open in the upcoming sessions listed below(for which we do have leaders confirmed!).
-[list available sessions by UTC and with time and date links]
-[list available sessions by UTC and with time and date links]
+
+- [list available sessions by UTC and with time and date links]
+- [list available sessions by UTC and with time and date links]
+
 Please add your name to one of these or another session. I apologize for any inconvenience this has caused for you and hope that you are able to reschedule your demonstration soon. I'm looking forward to having you in our instructor community.
 
-Sincerely,
+Sincerely,  
 [Name]
 
 #### Teaching demo cancelled - Trainers
@@ -73,7 +75,7 @@ This is just a quick notice that we’ve had to cancel a teaching demo for this 
 
 As always, if you haven’t led a teaching demo before, now’s a great time to start! You can get a feel for how they are run by observing someone else’s demo session or watching a recorded [teaching demo session](https://www.youtube.com/watch?v=FFO2cq-3PPg). If you’ll be attending someone else’s training, please let the Trainer who is running the session know that you’ll be there. 
 
-Best,
+Best,  
 [Name]
 
 
@@ -85,32 +87,32 @@ I've updated the teaching demo Etherpad to include dates through the end of [Mon
 
 A few events still need coverage in [Month]. Please sign up on the Etherpad if you can take any of the following: 
 
-[list available sessions by UTC and with time and date links]
-[list available sessions by UTC and with time and date links]
+- [list available sessions by UTC and with time and date links]
+- [list available sessions by UTC and with time and date links]
 
 As always, if you haven’t led a teaching demo before, now’s a great time to start! You can get a feel for how they are run by observing someone else’s demo session or watching a recorded [teaching demo session](https://www.youtube.com/watch?v=FFO2cq-3PPg). If you’ll be attending someone else’s training, please let the Trainer who is running the session know that you’ll be there. 
 
 Thanks!
 
-All the best,
+All the best,  
 [Name]
 
 #### Discussion Meeting reminder
 Subject: Trainer Discussion meeting this week
 
-Hi all,
+Hi all,  
 Just a quick reminder that we'll be having our Trainer Discussion meeting this week. Please join us to share your recent instructor training experience and get advice about upcoming events. Meeting details are here: http://pad.software-carpentry.org/trainers.
 
-All the best,
+All the best,  
 [Name]
 
 #### Business Meeting reminder
 Subject: Trainer Business meeting this week
 
-Hi all,
+Hi all,  
 Just a quick reminder that we’ll be having our Trainer Business meeting this week. Please check out the agenda and join here: http://pad.software-carpentry.org/trainers.
 
-All the best,
+All the best,  
 [Name]
 
 #### Business Meeting notes available
@@ -120,5 +122,5 @@ Hi all,
 
 Thank you to all who attended our Business meetings this week. For those who weren’t able to attend, please read through the meeting notes to stay informed about important issues affecting the Trainer community. If you have any questions or comments, contact [Erin Becker](mailto:ebecker@carpentries.org) or send a mail to the Trainers list.
 
-Best,
+Best,  
 [Name]

--- a/topic_folders/instructor_training/trainer_coordinator.md
+++ b/topic_folders/instructor_training/trainer_coordinator.md
@@ -10,14 +10,6 @@ Weekly:
 - If one week before the demo is scheduled to take place, there is still no Trainer available, email [team@carpentries.org](mailto:team@carpentries.org). The Carpentries staff will try to find a staff member to cover the demo.
 - If three business days before the demo, there is still no one available to lead, send [an email](#teaching-demo-cancelled-trainees) to the trainees who are signed up. Also, change the status to “Cancelled” on the Etherpad and [notify the Trainers group](#teaching-demo-cancelled-trainers) that we had to cancel an event.
 
-Monthly:
-- Send out reminders to the Trainers mailing list and Slack channel about upcoming [Trainer Discussion](#discussion-meeting-reminder) and [Business meetings](#business-meeting-reminder).
-- Take notes in Trainer Business meetings. 
-  - If not available to take notes, coordinate a replacement notetaker. 
-  - Submit notes as a pull request to the [Trainers’ GitHub repository](https://github.com/carpentries/trainers/tree/master/minutes).
-  - Send [email to Trainers mailing list](#business-meeting-notes-available) and post to Slack channel after Business meetings with a link to the notes.
-    - Note: There is no need to take notes in Trainer Discussion meetings.
-
 Bi-monthly:
 - Add sessions for the next two months to the [teaching demonstration Etherpad](http://pad.software-carpentry.org/teaching-demos). 
 - Use the [Event Time Announcer](https://www.timeanddate.com/worldclock/fixedform.html) to create a new event. Set the event location as “UTC”. 
@@ -28,6 +20,14 @@ Bi-monthly:
   - Events are listed on the community calendar as recurring with no end date. They will only need to be modified if there are changes made to the teaching demo schedule.
   - If you do not have edit access to the community calendar, contact [team@carpentries.org](mailto: team@carpentries.org).
 - [Email the Trainers mailing list](link to template) and post a message to the [Trainer Slack channel](#new-teaching-demos-available) asking people to sign up for teaching demos for the next two months. 
+
+Monthly:
+- Send out reminders to the Trainers mailing list and Slack channel about upcoming [Trainer Discussion](#discussion-meeting-reminder) and [Business meetings](#business-meeting-reminder).
+- Take notes in Trainer Business meetings. 
+  - If not available to take notes, coordinate a replacement notetaker. 
+  - Submit notes as a pull request to the [Trainers’ GitHub repository](https://github.com/carpentries/trainers/tree/master/minutes).
+  - Send [email to Trainers mailing list](#business-meeting-notes-available) and post to Slack channel after Business meetings with a link to the notes.
+    - Note: There is no need to take notes in Trainer Discussion meetings.
 
 ### Email templates (Trainer Coordinator) 
 

--- a/topic_folders/instructor_training/trainer_coordinator.md
+++ b/topic_folders/instructor_training/trainer_coordinator.md
@@ -1,0 +1,124 @@
+## Trainer Coordinator
+
+The Trainer Coordinator plays an essential role in The Carpentries community by ensuring that teaching demonstrations run smoothly and by coordinating meetings for the Trainers group. The duties for this position are estimated to take about two hours per month.
+
+### Duties
+
+Weekly:
+- Check the [teaching demonstration Etherpad](http://pad.software-carpentry.org/teaching-demos) to ensure that all events for the next two weeks have Trainers listed. 
+- If any events don’t have a Trainer listed, send out a reminder to the [Trainer Slack channel](https://swcarpentry.slack.com/messages/G7A6ED1SA/details/) and the [Trainer mailing list](mailto:trainers@lists.software-carpentry.org) asking Trainers to sign up. See the [email templates](#teaching-demos-without-hosts) for suggested language.
+- If one week before the demo is scheduled to take place, there is still no Trainer available, email [team@carpentries.org](mailto:team@carpentries.org). The Carpentries staff will try to find a staff member to cover the demo.
+- If three business days before the demo, there is still no one available to lead, send [an email](#teaching-demo-cancelled-trainees) to the trainees who are signed up. Also, change the status to “Cancelled” on the Etherpad and [notify the Trainers group](#teaching-demo-cancelled-trainers) that we had to cancel an event.
+
+Monthly:
+- Send out reminders to the Trainers mailing list and Slack channel about upcoming [Trainer Discussion](#discussion-meeting-reminder) and [Business meetings](#business-meeting-reminder).
+- Take notes in Trainer Business meetings. 
+  - If not available to take notes, coordinate a replacement notetaker. 
+  - Submit notes as a pull request to the [Trainers’ GitHub repository](https://github.com/carpentries/trainers/tree/master/minutes).
+  - Send [email to Trainers mailing list](#business-meeting-notes-available) and post to Slack channel after Business meetings with a link to the notes.
+    - Note: There is no need to take notes in Trainer Discussion meetings.
+
+Bi-monthly:
+- Add sessions for the next two months to the [teaching demonstration Etherpad](http://pad.software-carpentry.org/teaching-demos). 
+- Use the [Event Time Announcer](https://www.timeanddate.com/worldclock/fixedform.html) to create a new event. Set the event location as “UTC”. 
+  - Set the month, day, year, hour, minute, and second to reflect the recurring times on the Community Calendar. 
+  - Click “show result” and verify that the event is displaying in UTC. It will also display in your computer’s system time. 
+  - Add the link to the [teaching demonstration Etherpad](http://pad.software-carpentry.org/teaching-demos).
+- Make sure that the sessions are also listed on the community calendar. 
+  - Events are listed on the community calendar as recurring with no end date. They will only need to be modified if there are changes made to the teaching demo schedule.
+  - If you do not have edit access to the community calendar, contact [team@carpentries.org](mailto: team@carpentries.org).
+- [Email the Trainers mailing list](link to template) and post a message to the [Trainer Slack channel](#new-teaching-demos-available) asking people to sign up for teaching demos for the next two months. 
+
+### Email templates (Trainer Coordinator) 
+
+#### Teaching demos without hosts
+Subject: Need hosts for upcoming teaching demos
+
+Dear Trainers, 
+
+Thanks to everyone for signing up for leading teaching demonstrations in the coming weeks. Please note that we are missing a Trainer to lead a session on [time and date UTC] [time and date link]. If you are available to lead, please add your name to the Etherpad. If we don’t have a host scheduled one week before the event we will need to cancel the demo and ask trainees to reschedule. 
+
+Here are some additional events in the next month that don’t have a Trainer listed yet. Please sign up on the Etherpad if you’re available.
+
+[list available sessions by UTC and with time and date links]
+[list available sessions by UTC and with time and date links]
+
+As always, if you haven’t led a teaching demo before, now’s a great time to start! You can get a feel for how they are run by observing someone else’s demo session or watching a recorded [teaching demo session](https://www.youtube.com/watch?v=FFO2cq-3PPg). If you’ll be attending someone else’s training, please let the Trainer who is running the session know that you’ll be there. 
+
+If you have any questions about running a teaching demo, please contact [Erin Becker](mailto: ebecker@carpentries.org).
+
+Thank you!
+[Name]
+
+
+#### Teaching demo cancelled - trainees
+Subject: Teaching demo cancelled - please reschedule
+
+Dear checkout participant,
+
+Thank you for signing up to do your teaching demonstration next week at [time in UTC from Etherpad] [time and date link]. Unfortunately, due to lack of volunteer availability, we need to cancel this session. There are still spots open in the upcoming sessions listed below(for which we do have leaders confirmed!).
+[list available sessions by UTC and with time and date links]
+[list available sessions by UTC and with time and date links]
+Please add your name to one of these or another session. I apologize for any inconvenience this has caused for you and hope that you are able to reschedule your demonstration soon. I'm looking forward to having you in our instructor community.
+
+Sincerely,
+[Name]
+
+#### Teaching demo cancelled - Trainers
+Subject: Teaching demo cancelled - no host
+
+Dear Trainers, 
+
+This is just a quick notice that we’ve had to cancel a teaching demo for this coming week due to lack of Trainer availability. I’ve already followed up with the trainees who were scheduled to teach during that session and asked them to reschedule. If you haven’t lead a teaching demo in a while, please check out the upcoming sessions on our Etherpad: http://pad.software-carpentry.org/teaching-demos and sign up if you’re available.
+
+As always, if you haven’t led a teaching demo before, now’s a great time to start! You can get a feel for how they are run by observing someone else’s demo session or watching a recorded [teaching demo session](https://www.youtube.com/watch?v=FFO2cq-3PPg). If you’ll be attending someone else’s training, please let the Trainer who is running the session know that you’ll be there. 
+
+Best,
+[Name]
+
+
+#### New teaching demos available
+Subject: New teaching demos available for [Months]
+
+Hi folks,
+I've updated the teaching demo Etherpad to include dates through the end of [Month]. It would be great if everyone could check out the available time slots and sign up. Please remember that we need each Trainer to run one teaching demo every three months in order to cover all of the events.
+
+A few events still need coverage in [Month]. Please sign up on the Etherpad if you can take any of the following: 
+
+[list available sessions by UTC and with time and date links]
+[list available sessions by UTC and with time and date links]
+
+As always, if you haven’t led a teaching demo before, now’s a great time to start! You can get a feel for how they are run by observing someone else’s demo session or watching a recorded [teaching demo session](https://www.youtube.com/watch?v=FFO2cq-3PPg). If you’ll be attending someone else’s training, please let the Trainer who is running the session know that you’ll be there. 
+
+Thanks!
+
+All the best,
+[Name]
+
+#### Discussion Meeting reminder
+Subject: Trainer Discussion meeting this week
+
+Hi all,
+Just a quick reminder that we'll be having our Trainer Discussion meeting this week. Please join us to share your recent instructor training experience and get advice about upcoming events. Meeting details are here: http://pad.software-carpentry.org/trainers.
+
+All the best,
+[Name]
+
+#### Business Meeting reminder
+Subject: Trainer Business meeting this week
+
+Hi all,
+Just a quick reminder that we’ll be having our Trainer Business meeting this week. Please check out the agenda and join here: http://pad.software-carpentry.org/trainers.
+
+All the best,
+[Name]
+
+#### Business Meeting notes available
+Subject: Trainer Business meetings notes
+
+Hi all,
+
+Thank you to all who attended our Business meetings this week. For those who weren’t able to attend, please read through the meeting notes to stay informed about important issues affecting the Trainer community. If you have any questions or comments, contact [Erin Becker](mailto:ebecker@carpentries.org) or send a mail to the Trainers list.
+
+Best,
+[Name]


### PR DESCRIPTION
Hey @ErinBecker , 
2 things: 

1. the hyperlink isn't working -  
  If you do not have edit access to the community calendar, contact [team@carpentries.org](mailto: team@carpentries.org).

2. The link isn't provide. Not sure which one you wanted to include
[Email the Trainers mailing list](link to template) and post a message to the Trainer Slack channel asking people to sign up for teaching demos for the next two months.