### PR TITLE
Fix #193 by commenting-out typekit_id

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -105,7 +105,7 @@ html_theme = "sphinx_rtd_theme"
 # documentation.
 #
 html_theme_options = {
-    'typekit_id': '',
+    #'typekit_id': '',
     'canonical_url': '',
     'analytics_id': '',
     'logo_only': False,


### PR DESCRIPTION
Some warnings persist, though:

```
[...] Unsupported inline type Hardbreak
[...] Pygments lexer name u'' is not known
[...] html_static_path entry u'/Users/.../Carpentries/handbook/_static' does not exist
```