### PR TITLE
Fixing path to email template in maintainer topic

### DIFF
--- a/topic_folders/instructor_training/trainers_guide.md
+++ b/topic_folders/instructor_training/trainers_guide.md
@@ -39,7 +39,7 @@ A calendar for upcoming instructor training events is [here](http://carpentries.
 
 ###### Immediately after the event
 -  Send a list of those who completed the training to checkout@carpentries.   
--  Send an email to trainees thanking them for participating and linking to [checkout checklist][checkout-checklist] using [this template](email_templates.html#email-after-training-event)  
+-  Send an email to trainees thanking them for participating and linking to [checkout checklist][checkout-checklist] using [this template](email_templates_trainers.html#email-after-training-event)  
 -  Review survey results and prepare to discuss at upcoming [Trainers discussion meeting][trainer-pad].  
 -  File any relevant issues or PRs to the [instructor training repo][training-repo].  
 
@@ -112,7 +112,7 @@ If you would like to watch an example teaching demo, there is a recording of one
 ##### After the Demo 
 -  Email checkout@carpentries.org with names, pass/fail, and SWC/DC for each of your trainees.  
 -  Clear Etherpad of data from your session.  
--  Send each trainee an email letting them know they [passed](email_templates.html#trainee-did-pass-teaching-demo) or [did not pass](email_templates.html#trainee-didnt-pass-teaching-demo) the teaching demo. If needed, let them know the reason they did not pass and asking them to retry.
+-  Send each trainee an email letting them know they [passed](email_templates_trainers.html#trainee-did-pass-teaching-demo) or [did not pass](email_templates_trainers.html#trainee-didnt-pass-teaching-demo) the teaching demo. If needed, let them know the reason they did not pass and asking them to retry.
 
 ##### Not Good Starting Points for Demos
 Any episode other than those listed below should make an okay starting point for a teaching demonstration. 

--- a/topic_folders/instructor_training/trainers_training.md
+++ b/topic_folders/instructor_training/trainers_training.md
@@ -85,11 +85,11 @@ Total time commitment for new Trainers:
 
 1. Director of Instructor Training and Carpentries staff will decide on goals for Trainer recruitment.
 1. [Trainer Application](https://docs.google.com/forms/d/e/1FAIpQLSchAJhZiLSVmqSab1QxG1H30tCAHg_BcUwfctnJpzIhOVo1Bg/viewform?usp=sf_link) will be modified to reflect these goals.
-1. Open application period will be announced via Carpentries platforms including Twitter, Facebook, the Discuss email list, and blogs. Ask relevant community members to promote within their networks as well.  Personal invitations can be sent with [this email template](email_templates.html#recruiting-new-trainers).
+1. Open application period will be announced via Carpentries platforms including Twitter, Facebook, the Discuss email list, and blogs. Ask relevant community members to promote within their networks as well.  Personal invitations can be sent with [this email template](email_templates_admin.html#recruiting-new-trainers).
 1. Ensure communication emphasizes overall goals.
 1. Ask 2-3 existing Trainers to help review applications in line with defined goals. There is no rubric for this.  Reviewers should leave notes supporting their rankings.  
 1. Consolidate rankings, adding discretionary points for gaps in representation by characteristics like gender, race, geography, and experience.
-1. Notify accepted applicants using [this email template](email_templates.html#accepting-new-trainers).
+1. Notify accepted applicants using [this email template](email_templates_admin.html#accepting-new-trainers).
 1. Schedule Book Club meetings across time zones.
 1. Inform the Communications Lead so he/she can promote this.
 1. Update the [Trainer training Etherpad](http://pad.software-carpentry.org/trainer-training).


### PR DESCRIPTION
Hi,

I found some dead link to email templates in maintainer topic. I tried to fix them

Bérénice