### PR TITLE
instructor profile update instructions

### DIFF
--- a/topic_folders/instructors/index.rst
+++ b/topic_folders/instructors/index.rst
@@ -1,0 +1,5 @@
+.. toctree::
+   :maxdepth: 2
+   :glob:
+   
+   instructor-profile.md 

--- a/topic_folders/instructors/instructor-profile.md
+++ b/topic_folders/instructors/instructor-profile.md
@@ -1,0 +1,13 @@
+## Instructor Profile
+
+We maintain a record of information for each of our instructors in our AMY database system. To keep your AMY profile up-to-date you can [login to AMY](https://amy.software-carpentry.org/) using your GitHub account. If you are unable to login to AMY please submit your GitHub username to [team@carpentries.org](mailto:team@carpentries.org) and the administrative team will get your profile updated allowing you to login. 
+
+We use instructor profiles to help us identify instructors for workshops and to keep track of when and where you teach workshops. We also ask for social profile information as well as your ORCID and personal website. All of this information can be published on the [instructor page](https://carpentries.org/instructors) of our website. Being included on our website is strictly opt-in. You must login to your instructor profile and check the box "consent to publish profile" or your
+instructor information **will not** be included in our directory. 
+
+
+## Logging in 
+
+If you are an Instructor we ask that you please use the "Login with Github account" button. If you're unable to login, please notify [team@carpentries.org](mailto:team@carpentries.org) with your GitHub username, once it is added to your profile you will be able to login.
+
+![AMY Database tool login window, allowing login with username/password or GitHub account](https://docs.carpentries.org/_images/amy_login_screen.png)


### PR DESCRIPTION
This is not linked into the main TOC yet, I'd like to let @maneesha decide when and where it should go in and live, but I wanted to write it up to make it ready to go. It seems we could consolidate some other "instructor" related material to this section. Let me know if this isn't the right place and I can PR it to a more appropriate location. For now I'm looking for a stable link to point people to at the top of the instructors page so people can find instructions for how to login and update profiles. 