### PR TITLE
Fix extra text typo in trainers guide

### DIFF
--- a/topic_folders/instructor_training/trainers_guide.md
+++ b/topic_folders/instructor_training/trainers_guide.md
@@ -112,7 +112,7 @@ If you would like to watch an example teaching demo, there is a recording of one
 ##### During the Demo (Troubleshooting)
 - If a trainee is using Linux and gets the error message "Can not start share, wayland has not been supported yet, 
 please use x11 instead", have them log out of Zoom and log back in. On the login screen there is a gear with a dropdown menu there choose the option with x11.
-- If a trainee is teaching a Python lesson and their Jupyter notebook doesn't start, direct them to I pointed her http://jupyter.org/try.
+- If a trainee is teaching a Python lesson and their Jupyter notebook doesn't start, direct them to http://jupyter.org/try.
 
 ##### After the Demo 
 -  Email checkout@carpentries.org with names, pass/fail, and SWC/DC for each of your trainees.  


### PR DESCRIPTION
I think this was just a typo from this commit: 81b96aed4226a5877e64a258ab8b3cd873d8310d
Or at least it didn't make sense to me.