### PR TITLE
Update all trainer meeting references

### DIFF
--- a/topic_folders/instructor_training/duties_agreement.md
+++ b/topic_folders/instructor_training/duties_agreement.md
@@ -15,7 +15,7 @@ I understand that the secondary learning outcomes of workshops are as important 
 I understand that it is important to keep up to date and in touch with the Trainer community so that my teaching will reflect current practices and curriculum. Therefore, to be an active Trainer, I agree to:
 - Teach at least two instructor training events per year  
 - Host on average four teaching demonstrations per year  (1 per quarter)  
-- Regularly attend [Trainer Discussion and Business meetings](trainers_guide.html#trainer-meetings) when possible and read meeting minutes/notes when I am not able to attend  
+- Regularly attend [Trainer meetings](trainers_guide.html#trainer-meetings) when possible and read meeting minutes/notes when I am not able to attend  
 - Read emails sent to the Trainer listserv  
 - Keep up-to-date with the instructor training curriculum  
 - Teach a curriculum that fulfills all of the current requirements for instructor certification  

--- a/topic_folders/instructor_training/email_templates_admin.md
+++ b/topic_folders/instructor_training/email_templates_admin.md
@@ -331,7 +331,7 @@ If you're interested in being part of this cohort, please try to complete the fo
 
 4) Please also fill out your availability for instructor training events for [ month through month ] and add your name to the Trainers list in the second tab. This cohort of Trainers will be ready to co-teach instructor training events by the end of [ month ] and to teach on their own shortly after that.
 
-5) Please add upcoming Trainer Business and Discussion meetings (http://pad.software-carpentry.org/trainers) to your calendar. These are also on the Community Calendar. Each of these is held in two different time zones - you don't need to attend both meetings, but you're welcome to!
+5) Please add upcoming Trainer meetings (http://pad.software-carpentry.org/trainers-backup) to your calendar. These are also on the Community Calendar. Each of these is held in two different time zones - you don't need to attend both meetings, but you're welcome to!
 
 6) Please sign up for the Trainers email list (http://carpentries.topicbox.com/groups/trainers) if you haven't already done so.
 

--- a/topic_folders/instructor_training/trainers_guide.md
+++ b/topic_folders/instructor_training/trainers_guide.md
@@ -1,7 +1,7 @@
 ### Trainers Guide
 
 #### Trainer Meetings
-The Trainers group meets regularly. Our meetings include three sections: 1)Discussion, where we share experiences and get advice about running instructor training events, 2) Announcements, and 3) a Topic of the Month, which may include curriculum updates, active conversations about instructor training occurring elsewhere, guest presentations, etc. Upcoming meetings are listed on [our Etherpad][trainer-pad] and on the [Community Calendar][community-calendar]. If you are not a Trainer, but are interested in joining a meeting, please contact Erin Becker (ebecker@carpentries.org). Minutes for these meetings [are available][trainer-minutes].
+The Trainers group meets regularly. Our meetings include three sections: 1) Discussion, where we share experiences and get advice about running instructor training events, 2) Announcements, and 3) Topic of the Month, which may include curriculum updates, active conversations occurring on GitHub or other Trainer channels, guest presentations, etc. Upcoming meetings are listed on [our Etherpad][trainer-pad] and on the [Community Calendar][community-calendar]. If you are not a Trainer, but are interested in joining a meeting, please contact Erin Becker (ebecker@carpentries.org). Minutes for these meetings [are available][trainer-minutes].
 
 #### Signing up to Teach an Instructor Training Event
 

--- a/topic_folders/instructor_training/trainers_guide.md
+++ b/topic_folders/instructor_training/trainers_guide.md
@@ -1,7 +1,7 @@
 ### Trainers Guide
 
 #### Trainer Meetings
-The Trainers group meets regularly. We have two types of meetings - business meetings, focused on discussing curricular and policy changes, and discussion meetings, where we share experiences and get advice about running instructor training events. Upcoming meetings are listed on [our Etherpad][trainer-pad] and on the [Community Calendar][community-calendar]. If you are not a Trainer, but are interested in joining a meeting, please contact Erin Becker (ebecker@carpentries.org). Minutes for these meetings [are available][trainer-minutes].
+The Trainers group meets regularly. Our meetings include three sections: 1)Discussion, where we share experiences and get advice about running instructor training events, 2) Announcements, and 3) a Topic of the Month, which may include curriculum updates, active conversations about instructor training occurring elsewhere, guest presentations, etc. Upcoming meetings are listed on [our Etherpad][trainer-pad] and on the [Community Calendar][community-calendar]. If you are not a Trainer, but are interested in joining a meeting, please contact Erin Becker (ebecker@carpentries.org). Minutes for these meetings [are available][trainer-minutes].
 
 #### Signing up to Teach an Instructor Training Event
 
@@ -44,7 +44,7 @@ A calendar for upcoming instructor training events is [here](http://carpentries.
 -  File any relevant issues or PRs to the [instructor training repo][training-repo].  
 
 ###### Long-term after the event 
--  Join a [Trainer discussion meeting][trainer-pad] to discuss how your event went.   
+-  Join a [Trainer meeting][trainer-pad] to discuss how your event went.   
 
 #### Differences Between In-person and Online Training Events
 
@@ -162,7 +162,7 @@ Any episode other than those listed below should make an okay starting point for
 
 [trainer-agreement]: ../instructor_training/trainers_guide.html#trainer-agreement
 [trainer-process]: ../instructor_training/trainers_training.html
-[trainer-pad]: http://pad.software-carpentry.org/trainers
+[trainer-pad]: http://pad.software-carpentry.org/trainers-backup
 [community-calendar]: https://software-carpentry.org/join/#community-events
 [trainer-minutes]: https://github.com/carpentries/trainers/tree/master/minutes
 [etherpad-template]: http://pad.software-carpentry.org/ttt-template

--- a/topic_folders/instructor_training/trainers_training.md
+++ b/topic_folders/instructor_training/trainers_training.md
@@ -9,8 +9,8 @@ Instructor Trainers agree to abide by the [Code of Conduct](http://www.datacarpe
 
 * Read [How Learning Works](https://www.amazon.com/How-Learning-Works-Research-Based-Principles/dp/0470484101/) by Susan Ambrose and discuss in book club format with Trainers-in-training. Preliminary reading schedule.
   * Time commitment: 1 hour per week for 8 weeks meetings; can miss one meeting; ~10 hours reading
-* Join Trainer Discussion and Business meetings 
-  * Time commitment: 1 hour every 2 weeks for 3 months; can miss one of each meeting
+* Join Trainer meetings 
+  * Time commitment: 1 hour per month; can miss one meeting
 * Shadow a teaching demonstration session (after finishing book club)
   * Time commitment: 1 hour one time
 * Shadow at least half a day of an online instructor training event (after finishing book club)


### PR DESCRIPTION
Updating with information that reflects changes to trainer meeting structure. Also updates web addresses to point to currently-used 'trainer-backup' etherpad.