### PR TITLE
added presentations page to communications

### DIFF
--- a/topic_folders/communications/presentations.md
+++ b/topic_folders/communications/presentations.md
@@ -1,0 +1,18 @@
+### Presentations
+
+It's great for community members to give presentations on The Carpentries! 
+Include your work with The Carpentries in a presentation, or you're more than welcome
+to give talks or discuss the organization in general.
+
+There are some general Google slide decks as well as ones more tailored to
+particular topics or events. The General slide deck is CC0, so you're welcome to use it how you wish. Please just keep attributions on individual figures or photos if they are there.
+
+Other slide decks are CC-BY.
+
+[General Carpentries slide deck CC0](https://docs.google.com/presentation/d/1XGD5v7bBTTK9w7a1uZh5i--z22kFnj8_22xCOfezoLE/edit)
+
+[Google drive with slide decks](https://drive.google.com/drive/folders/12D0D9F2GJX4TIwzWkSHYdaI0VFdYYCul)
+
+[List of past Data Carpentry presentations on Zotero](https://www.zotero.org/groups/597593/datacarpentry/items/collectionKey/WT38F37Q) including abstracts and links to slide decks.
+
+Updates to slide decks or contributing your slide decks is encouraged and welcomed too! 


### PR DESCRIPTION
Presentations has been linked from 'commons', but we get quite a few questions about if we have slide decks available, so it would be good to make it a more obvious menu item. 