### PR TITLE
removing ableist language

### DIFF
--- a/topic_folders/hosts_instructors/instructor_tips.md
+++ b/topic_folders/hosts_instructors/instructor_tips.md
@@ -41,7 +41,7 @@ The Carpentries Code of Conduct is a key tool for fostering and upholding an inc
 > 
 > Apart from prohibiting the obviously unacceptable stuff like harassing or vilifying anyone, it also means this:
 > 
-> * Please don't make someone feel stupid because they don't know what you know.
+> * Please don't make someone feel clueless because they don't know what you know.
 > * Please don't try to make anyone feel bad because of the hardware or software tools they use.
 > * Please don't talk over people - everyone has an equal right to be heard.
 > * Please don't mock people's questions.


### PR DESCRIPTION
We should remove wording from the Handbook that is a slur. Especially in discussion of the Code of Conduct and really especially in a context of teaching instructors how to talk about a code of conduct if they are unaccustomed to doing so.

I think "clueless" captures what we mean here: don't make someone feel like they don't know anything just because they don't know what you know.