### PR TITLE
Update workshops list link

### DIFF
--- a/topic_folders/hosts_instructors/index.rst
+++ b/topic_folders/hosts_instructors/index.rst
@@ -1,7 +1,7 @@
 TEACHING AND HOSTING
 =======================
 
-Opportunities for certified instructors to teach Carpentries workshops are listed `here <https://docs.google.com/spreadsheets/d/1gYmN7zn1dcrQTFGunsCq6Pqj82Hs2csoCL9hjt0o3uo/edit#gid=0>`_.  Join the `instructors mailing list <http://carpentries.topicbox.com/groups/instructors>`_ to be notified when new opportunities are posted.
+Opportunities for certified instructors to teach Carpentries workshops are listed `here <https://docs.google.com/spreadsheets/d/1YhTAzEalDqKUowgej7aRa7E1K0XcB6ZezoVUt6VN2qY/edit#gid=0>`_.  Join the `instructors mailing list <http://carpentries.topicbox.com/groups/instructors>`_ to be notified when new opportunities are posted.
 
 For centrally organized workshops, the Workshop Administrator will guide the host and instructor on following through on all these steps.
 


### PR DESCRIPTION
The link previously on this page pointed to a Google sheet that described itself as ‘deprecated’, with the provided link as new canonical reference.