### PR TITLE
Fix typo in URL leading to a 404

### DIFF
--- a/topic_folders/for_instructors/current_instructors.md
+++ b/topic_folders/for_instructors/current_instructors.md
@@ -54,7 +54,7 @@ information **will not** be included in our listing.
 username/password or GitHub account](https://docs.carpentries.org/_images/amy_login_screen.png)
 
 #### Setting up a workshop
-Please see our [Teaching and Hosting](https://docs.carpentries.org/topic_folders/hosts_Instructors/index.html) section for 
+Please see our [Teaching and Hosting](https://docs.carpentries.org/topic_folders/hosts_instructors/index.html) section for 
 instructions on setting up and running workshops. This includes links to our checklists and describes the surveys we use to assess learners' and Instructors' experiences. Also check out our [Workshop Administration section](https://docs.carpentries.org/topic_folders/workshop_administration/index.html)
 
 ### Setting up a workshop website


### PR DESCRIPTION
https://docs.carpentries.org/topic_folders/for_instructors/current_instructors.html#setting-up-a-workshop contains a link to "Teaching and Hosting" which has a typo (https://docs.carpentries.org/topic_folders/hosts_Instructors/index.html with a capital *I* in Instructors, which should be a small *i*, fixed in this PR).