### PR TITLE
Clarify Readme sphinx/readthedocs info

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,36 +1,52 @@
 ### About this site
 
-This site is built using [Read the Docs](https://github.com/rtfd/sphinx_rtd_theme).  See the [Getting Started](https://docs.readthedocs.io/en/latest/getting_started.html) section.
+This site is built using the [Sphinx](http://www.sphinx-doc.org/en/stable/) documentation generator (a Python tool) and the [Read the Docs theme](https://github.com/rtfd/sphinx_rtd_theme) for the style. (Not to be confused with readthedocs.io - the site is _not_ hosted at readthedocs.io!) 
 
-It uses the [Sphinx](https://github.com/rtfd/sphinx_rtd_theme) theme.
+For more information about using Sphinx, see the [Getting Started guide (sphinx-doc.org)](http://www.sphinx-doc.org/en/stable/usage/quickstart.html) or the [Quick Start (readthedocs.io)](https://docs.readthedocs.io/en/latest/intro/getting-started-with-sphinx.html#quick-start) for an explanation of how to use Sphinx.
 
 #### Required dependencies
+
+To install the required dependencies (Sphinx and the ReadTheDocs Sphinx theme), execute the following command from the repository directory to install all Python dependencies:
+
 ```
 pip install -r requirements.txt 
 ```
 
-After installing Read the Docs packages and the Sphinx theme, build the site locally using
+After installing the dependencies, you can build the site locally by executing the following command from the repository:
 
-`$ make html`
+```
+$ make html
+```
 
-Open the file `/_build/html/index.html` to preview the site locally.
+Open the file `_build/html/index.html` to preview the site locally. Python offers a quick way to run a web server to serve local files. Run the following:
 
-After making changes, run `make html` again to view your changes.  You may need to delete the contents of the `/_build/`  directory before running `make html` to force the changes to refresh.
+```
+$ cd _build/html
 
-If new files or folders are added to the project, `index.rst` will need to be updated.
+# Python 2:
+$ python2 -m SimpleHTTPServer
+
+# Python 3:
+$ python3 -m http.server
+```
+
+In both cases, a local web server will be run on port 8000, so navigate to <http://localhost:8000> in your browser to view the site locally.
+
+You can make changes to the contents of the repository, and re-run `make html`, to update the website contents. If you are having problems with the site not refreshing, you can delete the contents of the `_build` directory (which are automatically generated) with `rm -fr _build/*`.
+
+If new files or folders are added to the Handbook, `index.rst` will need to be updated for those to be included in the final site by Sphinx.
 
 #### Site structure
 
-The root level `index.rst` generates main categories the sidebar navigation.  Each sub-section is a folder in the `topic_folders` directory. Each folder within the `topic_folders` directory has its own `index.rst` file. These then expand into the subcategories in each directory.
+The root level `index.rst` generates the main categories the sidebar navigation.  Each sub-section is a folder in the `topic_folders` directory. Each folder within the `topic_folders` directory has its own `index.rst` file. These then expand into the subcategories in each directory.
 
 Within each folder's `index.rst` file, the section heading is defined by a string of  `=` beneath it. Subheadings can be defined using `###` in each markdown file or by a heading with `-` under it in the `index.rst` file.
 
 
 #### Additional information
-This site is built from the master branch of [this repo](https://github.com/carpentries/handbook/). Changes can be previewed live [here](http://docs-src.carpentries.org/).  Changes to the [actual site](https://docs.carpentries.org/) will take several hours to go live as they're hosted by CDN.
 
-If you are making experimental changes to live content please be sure to do so in another branch. Draft content can be added to the [drafts folder](https://github.com/carpentries/usersguides/tree/master/drafts) in the master branch without breaking anything. Draft content is not built to the live site and these files may contain inaccurate or out of date information.
+This site is built from the master branch of [this repo (carpentries/handbook)](https://github.com/carpentries/handbook/). Changes can be previewed live here: <http://docs-src.carpentries.org/>.  Changes to the actual site <https://docs.carpentries.org/> will take several hours to go live once changes have been pushed to Github, since the contents of the site are behind a CDN (Content Distribution Network) that caches content.
 
+If you are making experimental changes to content please be sure to do so in a non-master, non-live branch. When your changes are complete and ready to be pushed to the live site, open a pull request in [carpentries/handbook](https://github.com/carpentries/handbook).
 
-
-
+Draft content can be added to the [drafts folder of the carpentries/userguides repo](https://github.com/carpentries/usersguides/tree/master/drafts) (in the master branch) without breaking anything. Draft content is not built to the live site and these files may contain inaccurate or out of date information.


### PR DESCRIPTION
This fixes an issue with the Readme, which described ReadTheDocs as the documentation system and Sphinx as the theme. It's actually the other way around. This also clarifies that ReadTheDocs is just a theme, and we are not using the readthedocs.io website to build or host this site.