### PR TITLE
Add version numbers to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-Sphinx
-sphinx_rtd_theme
-recommonmark
-sphinx-markdown-tables
-
+recommonmark>=0.5.0
+Sphinx>=1.8
+sphinx_rtd_theme>=0.4.2
+sphinx-markdown-tables>=0.0.9


### PR DESCRIPTION
I tested this versioned `requirements.txt` using a virtual environment and Anaconda Python 3.6.3, and all versions of the software installed okay, and I was able to successfully build the site and view it locally.

Commands to cleanly replicate in a virtual environment:

```
git clone https://github.com/carpentries/handbook
cd handbook
virtualenv vp
source vp/bin/activate
vp/bin/pip install -r requirements.txt
make html
```

Python version:

```
$ python --version
Python 3.6.3 :: Anaconda, Inc.
```