### PR TITLE
Update broken calendar links

### DIFF
--- a/drafts/incorporated/maintainer-training.md
+++ b/drafts/incorporated/maintainer-training.md
@@ -67,7 +67,7 @@ Before our first meeting, please:
 
 1) Sign up for the [Maintainer mailing list](http://carpentries.topicbox.com/groups/maintainers). This is a low-volume channel for communicating about issues relevant to the Maintainer community.
 
-2) Add Maintainer meetings to your schedule. The meeting times are listed on the [Maintainer Etherpad](http://pad.software-carpentry.org/maintainers) and on the [Community Calendar](https://software-carpentry.org/join/#calendar). The Maintainer monthly meetings are not mandatory, but are encouraged as a way of getting to know the more experienced Maintainers.
+2) Add Maintainer meetings to your schedule. The meeting times are listed on the [Maintainer Etherpad](http://pad.software-carpentry.org/maintainers) and on the [Community Calendar](https://carpentries.org/community/#community-events). The Maintainer monthly meetings are not mandatory, but are encouraged as a way of getting to know the more experienced Maintainers.
 
 If you have any questions, please let me know.
 

--- a/topic_folders/maintainers/email_templates.md
+++ b/topic_folders/maintainers/email_templates.md
@@ -35,7 +35,7 @@ Before our first meeting, please:
 
 1) Sign up for the [Maintainer mailing list](http://carpentries.topicbox.com/groups/maintainers). This is a low-volume channel for communicating about issues relevant to the Maintainer community.
 
-2) Add Maintainer meetings to your schedule. The meeting times are listed on the [Maintainer Etherpad](http://pad.software-carpentry.org/maintainers) and on the [Community Calendar](https://software-carpentry.org/join/#calendar). The Maintainer monthly meetings are not mandatory, but are encouraged as a way of getting to know the more experienced Maintainers.
+2) Add Maintainer meetings to your schedule. The meeting times are listed on the [Maintainer Etherpad](http://pad.software-carpentry.org/maintainers) and on the [Community Calendar](https://carpentries.org/community/#community-events). The Maintainer monthly meetings are not mandatory, but are encouraged as a way of getting to know the more experienced Maintainers.
 
 If you have any questions, please let me know.
 

--- a/topic_folders/maintainers/maintainers.md
+++ b/topic_folders/maintainers/maintainers.md
@@ -77,7 +77,7 @@ the onboarding process.
 
 The overall Maintainer community communicates using our [mailing list](http://carpentries.topicbox.com/groups/maintainers) and our [Slack channel](https://swcarpentry.slack.com/messages/C8H5LN44V/details/). If you don't already have a Slack account with the Carpentries, you can [create one](https://swc-slack-invite.herokuapp.com/).
 
-The Maintainer community meets monthly to discuss issues relevant to all lesson Maintainers. Our meeting schedule can be found on [our Etherpad](http://pad.software-carpentry.org/maintainers) and on the [community calendar](https://software-carpentry.org/join/#calendar).
+The Maintainer community meets monthly to discuss issues relevant to all lesson Maintainers. Our meeting schedule can be found on [our Etherpad](http://pad.software-carpentry.org/maintainers) and on the [community calendar](https://carpentries.org/community/#community-events).
 
 Each Lesson Team also has their own Slack channel. A link to join your lesson's Slack channel can be found
 in the README file in your lesson repository. 


### PR DESCRIPTION
While `software-carpentry.org/join` is redirected to `carpentries.org/join`, there is no mention of a calendar. This fixes that problem by updating the link to the actual calendar page.