### PR TITLE
Added staff immediate response checklist

### DIFF
--- a/topic_folders/policies/immediate-response-checklist.md
+++ b/topic_folders/policies/immediate-response-checklist.md
@@ -1,4 +1,4 @@
-## Carpentries Staff Immediate Response Checklist
+## The Carpentries Termed Suspension Checklist
 
 When a Code of Conduct (CoC) violation is found, one course of action is that activities in Carpentries channels (in-person and virtual) are monitored. In other cases, the community member is asked to take a termed suspension. When this is the resolution of the CoC committee, the following boundaries are enforced. The checklist below was created for incidents that require an immediate response, i.e. the community member is removed from all Carpentries engagement.
 

--- a/topic_folders/policies/immediate-response-checklist.md
+++ b/topic_folders/policies/immediate-response-checklist.md
@@ -1,0 +1,74 @@
+## Carpentries Staff Immediate Response Checklist
+
+When a Code of Conduct (CoC) violation is found, one course of action is that activities in Carpentries channels (in-person and virtual) are monitored. In other cases, the community member is asked to take a termed suspension. When this is the resolution of the CoC committee, the following boundaries are enforced. The checklist below was created for incidents that require an immediate response, i.e. the community member is removed from all Carpentries engagement.
+
+The intended outcomes for such a suspension are immediate, ongoing, and demonstrable changes in any areas of engagement for which the CoC deemed undesirable in the incident review. 
+
+### Online Communication and Communities
+Revoke access from the following communication channels and communities: 
+- [ ] Email lists on TopicBox 
+- [ ] Email lists on Google Groups
+  - [ ] Library Carpentry Governance Group
+  - [ ] Library Carpentry Maintainer Onboarding
+  - [ ] Code of Conduct Committee
+  - [ ] Carpentries Mentoring Groups 
+- [ ] Twitter - (@datacarpentry, @swcarpentry, @libcarpentry, @thecarpentries)
+- [ ] Blogs - (Data Carpentry, Software Carpentry, Library Carpentry, The Carpentries)
+- [ ] GitHub (carpentries, datacarpentry, swcarpentry, librarycarpentry, data-lessons, carpentrieslab)
+- [ ] Gitter - Library Carpentry Lobby
+- [ ] [Slack](https://swcarpentry.slack.com/messages)  
+- [ ] Facebook 
+- [ ] LinkedIn 
+
+Additionally, the community member will not be allowed to attend community discussions.
+
+### Teaching Workshops
+The suspended member will, for the duration of their suspension:
+- [ ] Be asked not to sign up for workshops on the Instructor Spreadsheet.
+- [ ] Not be able to participate as a helper at any workshops.
+- [ ] Be removed from Eventbrite login access.
+- [ ] Not be allowed to plan self-organized workshops.
+- [ ] Not be allowed to request or host centrally coordinated workshops.
+- [ ] Not be listed as an instructor on the “Instructors” webpage.
+- [ ] Be removed from the instructors email list.
+
+### Organizing Workshops 
+If the suspended member is a Workshop Administrator or serves in another role whereby they organize workshops for The Carpentries, for the duration of their suspension they will not have access to:
+- [ ] LastPass
+- [ ] AMY
+- [ ] Regional Email
+- [ ] Asana
+- [ ] HelpScout
+- [ ] Zoom
+- [ ] Workshop Administrator’s Slack Channel
+- [ ] Workshop Administrator’s Email List
+
+### Instructor Training
+The suspended member will, for the duration of their suspension, be removed from the “Our Trainers” web page. Additionally, the suspended member will not be allowed to: 
+- [ ] Teach Instructor Training or lead teaching demonstration sessions. The Deputy Director of Instructor Training (DDIT) will check the teaching demo Etherpad to ensure that the suspended member is not signed up to lead teaching demonstrations and will find a replacement Trainer as needed. 
+- [ ] Join Trainer meetings. The DDIT will check the meeting Etherpad, and if the suspended member is signed up to attend, will email them if needed to confirm they will not be in attendance. 
+- [ ] Post pull requests (PRs), issues, or comments to the Instructor Training GitHub repository. Write or administrative access to repositories will be removed for the duration of the suspension. 
+- [ ] Post to the Trainers Slack channel or mailing lists. The suspended member will be removed from these lists for the duration of their suspension. 
+- [ ] Participate in review of applications for open instructor training or Trainer training. 
+Participate as a learner in instructor training.
+
+### Trainer Training
+The suspended member will not be allowed to participate in Trainer Training (if they are currently enrolled) and will not be accepted for Trainer Training (if they apply during the suspension period). Additionally, they will not be allowed to shadow a current Carpentries Trainer. They may apply or reapply for future rounds of Trainer Training. 
+
+### Member Organisation and Local Activities
+The suspended member shall not be involved in officially branded Carpentries workshops or activities at the member or local site for the duration of the suspension. We expect the suspended member to assert that they will be able to carry out this suspension accordingly and to notify the CoC committee if this suspension will interfere with their expected employment duties. 
+
+If the suspension does affect employment duties or the suspended member is the key contact for a member site, the member will work with The Carpentries Executive Director to determine a course of action.
+
+### Lesson Development and Maintenance
+The suspended member will not be allowed to post PRs, issues, or comments to any repository in the carpentries, including but not limited to datacarpentry, swcarpentry, library carpentry, data-lessons, and carpentrieslab organizations. Administrative or write privileges to repositories in these organizations will be removed for the duration of the suspension.
+
+If the suspended member is a Maintainer, their name will be removed from the lessons page and they will not appear on the Maintainers page for the duration of their suspension. 
+
+### Executive Council
+If the suspended member is a member of the Executive Council, they will not participate in Executive Council responsibilities and will be removed from the Executive Council repositories and list of Executive Council members on the website for the duration of their suspension. The Executive Council will review the CoC incident to determine if a suspension will affect their long term position on the Executive Council.
+
+### Committees, Task Forces, and Other Interactions
+Involvement in all committees, communities, and task forces (African Task Force, Carpentries en LatinoAmérica, etc.) will be suspended. 
+
+- [ ] The suspended members ability to sign in to AMY to manage their own profile or other tasks will be revoked for the duration of their suspension.

--- a/topic_folders/policies/immediate-response-checklist.md
+++ b/topic_folders/policies/immediate-response-checklist.md
@@ -1,8 +1,12 @@
 ## The Carpentries Termed Suspension Checklist
 
-When a Code of Conduct (CoC) violation is found, one course of action is that activities in Carpentries channels (in-person and virtual) are monitored. In other cases, the community member is asked to take a termed suspension. When this is the resolution of the CoC committee, the following boundaries are enforced. The checklist below was created for incidents that require an immediate response, i.e. the community member is removed from all Carpentries engagement.
+As a part of their enforcement options, The Carpentries Code of Conduct (CoC) committee can place a community member in Termed Suspension, where the community member is removed from all Carpentries engagement for a period of time.
 
-The intended outcomes for such a suspension are immediate, ongoing, and demonstrable changes in any areas of engagement for which the CoC deemed undesirable in the incident review. 
+The goal of a Termed Suspension is to 1) limit a person's participation in virtual and in-person Carpentries spaces for a set time to create a safe space for the community, and 2) to give time and opportunity for the individual to review their response to the incident and demonstrate immediate, ongoing, and demonstrable changes as evaluated by the CoC committee before possible reinstatement.
+
+In most cases a Termed Suspension will only be enacted after an incident has been reviewed by the CoC committee and a resolution is reached. However, in severe situations, in particular where there is active harassment, the CoC committee may enact an immediate short-term Termed Suspension while an incident is under review.
+
+If there is a decision for a Termed Suspension, the following checklist is followed by the appropriate personnel to enact the Termed Suspension. In accordance with CoC confidentiality guidelines, only essential personnel will be involved in implementation of these actions.
 
 ### Online Communication and Communities
 Revoke access from the following communication channels and communities: 

--- a/topic_folders/policies/immediate-response-checklist.md
+++ b/topic_folders/policies/immediate-response-checklist.md
@@ -75,4 +75,4 @@ If the suspended member is a member of the Executive Council, they will not part
 ### Committees, Task Forces, and Other Interactions
 Involvement in all committees, communities, and task forces (African Task Force, Carpentries en LatinoAmérica, etc.) will be suspended. 
 
-- [ ] The suspended members ability to sign in to AMY to manage their own profile or other tasks will be revoked for the duration of their suspension.
+- [ ] The suspended member's ability to sign in to AMY to manage their own profile or other tasks will be revoked for the duration of their suspension.


### PR DESCRIPTION
Per [this issue](https://github.com/carpentries/coc-guidelines-taskforce/issues/11) I am adding a checklist to the Code of Conduct documentation for what procedure the staff needs to follow when responding to a CoC incident. We have not resolved updating all of the [CoC documentation](https://github.com/carpentries/coc-guidelines-taskforce/issues), so this PR should not be merged until that documentation has been updated. I would like for @tracykteal to review and make any necessary comments/edits, then we can merge when the CoC documentation is being merged.