### PR TITLE
Update about to include why the handbook was created

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,10 @@
+### Why was the handbook created
+
+Historically, information and resources related to [The Carpentries](https://carpentries.org/) have been spread across various websites, Google docs, GitHub repos, and more. The handbook is a one-stop shop that consolidates information on running a workshop, developing or maintaining lessons, participating in an instructor training event, and more! 
+
+Many community members have contributed to this handbook, and we welcome feedback on this Handbook. Feel free to submit issues or pull requests to [this GitHub repo](https://github.com/carpentries/handbook/) to improve this community resource.
+
+
 ### About this site
 
 This site is built using the [Sphinx](http://www.sphinx-doc.org/en/stable/) documentation generator (a Python tool) and the [Read the Docs theme](https://github.com/rtfd/sphinx_rtd_theme) for the style. (Not to be confused with readthedocs.io - the site is _not_ hosted at readthedocs.io!) 


### PR DESCRIPTION
The "about" section of the handbook dives right into the technical details of the site. I wonder if it makes sense to include some background and context first. 

This text was modified from the blog post https://carpentries.org/blog/2018/04/launch-handbook/