### PR TITLE
Add URL for swc-releases

### DIFF
--- a/topic_folders/lesson_development/lesson_release.md
+++ b/topic_folders/lesson_development/lesson_release.md
@@ -66,3 +66,5 @@ Checklist of tasks to complete before release:
 ### Upcoming Lesson Releases
 
 Information about upcoming lesson releases - coming soon!
+
+[swc-releases]: https://github.com/swcarpentry/swc-releases/


### PR DESCRIPTION
See diff ;-) https://docs.carpentries.org/topic_folders/lesson_development/lesson_release.html looked like this:

![grafik](https://user-images.githubusercontent.com/9948149/56654566-b2a51d80-6690-11e9-9377-d4138cbf6528.png)