### PR TITLE
Clarify use of Oxford comma.

### DIFF
--- a/topic_folders/communications/style-guide.md
+++ b/topic_folders/communications/style-guide.md
@@ -188,7 +188,7 @@ I spoke to my sisters, Olga Petrova, and Susanne De Vries (means I spoke to my s
 
 I spoke to my sisters, Olga Petrova and Susanne De Vries (this wrongly implies that Olga Petrova and Susanne De Vries are the sisters in question.)
  
-Carpentries style is to use the Oxford comma.
+Carpentries style is to prefer the Oxford comma unless necessary.
 
 ## P
 ##### per cent


### PR DESCRIPTION
Since we just enumerated circumstances in which use of the Oxford comma is discretionary to clarify meaning, I suggest softening the language requiring Oxford comma usage.