### PR TITLE
Removed mentoring groups schedule

### DIFF
--- a/topic_folders/instructor_development/mentoring_groups.md
+++ b/topic_folders/instructor_development/mentoring_groups.md
@@ -70,10 +70,6 @@ During the final week of the mentoring groups, we will host a virtual mentoring 
 
 Lastly, both mentors and mentees will receive a certificate! 
 
-### 2018-2019 Schedule
-
-- [2018-2019 Schedule](https://github.com/carpentries/instructor-development/blob/master/mentoring-groups/2018-2019-schedule.md)
-
 ### Mentor Agreement
 
 I agree to follow the [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) in all communications and interactions with The Carpentries community and to [promptly report any violations of the CoC](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#incident-reporting-guidelines) that I become aware of.


### PR DESCRIPTION
The Mentoring Chair is currently being onboarded so we are revising the schedule for mentoring groups. I will add it back once it's been revised.