### PR TITLE
Corrected spelling of defuse

### DIFF
--- a/topic_folders/policies/incident-response.md
+++ b/topic_folders/policies/incident-response.md
@@ -6,7 +6,7 @@ The checklists below outline the steps any community member (workshop host, [ins
 
 All Carpentries community members should feel empowered to enforce the Code of Conduct. 
 
-Ideally, we would all be able to diffuse an incident. In practice, we have varying comfort with situations depending on our current experience and the environment. Below are ways that you can be supportive and steps that you can take during or after an incident.
+Ideally, we would all be able to defuse an incident. In practice, we have varying comfort with situations depending on our current experience and the environment. Below are ways that you can be supportive and steps that you can take during or after an incident.
 
 If you can, move from being a bystander to being a Code of Conduct first responder. If you see something inappropriate happening, speak up. If you don't feel comfortable intervening, but feel someone should, please submit a report in person to a workshop host or instructor or via the [Code of Conduct incident report form][reporting-form] to the Code of Conduct committee.
 


### PR DESCRIPTION
This PR addresses #461:
Diffuse: spread over a wide area or between a large number of people.
Defuse: make (a situation) less tense or dangerous.

Thank you @LUS24.