### PR TITLE
Add pre-workshop survey to host checklist

### DIFF
--- a/topic_folders/hosts_instructors/hosts_instructors_checklist.md
+++ b/topic_folders/hosts_instructors/hosts_instructors_checklist.md
@@ -19,7 +19,7 @@ A workshop host contacts The Carpentries staff about running a workshop.  He or 
 * Get emergency contact information for instructors in case of last minute changes
 * Arrange for [required materials and equipment](workshop_needs.md)
 * Arrange for coffee, snacks, and/or lunch. We all learn better with fuel!
-* Email learners to remind them of workshop location, timing, and software installation requirements
+* Email learners to remind them of workshop location, timing, pre-workshop survey and software installation requirements
 * Organise a meetup with the instructors the day before the workshop.  While this is not always possible, it's useful for the host and instructors to get to know each other. This can be over coffee, dinner, or anything else that works for your team.
 
 **During the workshop, the host will**


### PR DESCRIPTION
I noticed that only the post-WS survey is mentioned. Here's a suggestion to include it as a task for the host.

Presumably, it would make a good dedicated item as well, earlier in the process, maybe at the time of the initial learner sign-up. What do you think?