### PR TITLE
Fix link to demos etherpad

### DIFF
--- a/topic_folders/instructor_training/trainers_guide.md
+++ b/topic_folders/instructor_training/trainers_guide.md
@@ -73,7 +73,7 @@ This table has moved. Suggested lessons are available in the [Instructor Trainin
 [training-repo]: http://carpentries.github.io/instructor-training/
 [zoom-home]: https://www.zoom.us/
 [demo-video]: https://www.youtube.com/watch?v=FFO2cq-3PPg
-[demo-pad]: http://pad.software-carpentry.org/teaching-demos-recovered
+[demo-pad]: https://pad.carpentries.org/teaching-demos-new
 [demo-rubric]: http://carpentries.github.io/instructor-training/demos_rubric/
 
 


### PR DESCRIPTION
The current pad doesn't work and the chat suggests to use this new URL.