### PR TITLE
Adjusting language for re-onboarding

### DIFF
--- a/topic_folders/instructor_training/duties_agreement.md
+++ b/topic_folders/instructor_training/duties_agreement.md
@@ -21,4 +21,4 @@ I understand that it is important to keep up to date and in touch with the Train
 - Teach a curriculum that fulfills all of the current requirements for instructor certification  
 - Provide feedback to other trainers and Carpentries staff about training events to help continue developing our offerings  
 
-I understand that The Carpentries staff need an accurate understanding of Trainer availability in order to plan instructor training events. If at any point I am no longer able to serve as a Trainer, I will let The Carpentries staff know. I understand that only active Trainers are voting members of the Trainer community, but that I will be able to re-activate my Trainer status at any time by resuming Trainer activities. 
+I understand that The Carpentries staff need an accurate understanding of Trainer availability in order to plan instructor training events. If at any point I am no longer able to serve as a Trainer, I will let The Carpentries staff know. I understand that only active Trainers are voting members of the Trainer community, but that I will be able to re-activate my Trainer status at any time by making arrangements with staff for re-onboarding. 


### PR DESCRIPTION
This change anticipates approval of re-onboarding requirements as suggested by community surveys and outlined in the draft Inactive status plan.