### PR TITLE
Changed the way "recommonmark" is loaded

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -26,27 +26,18 @@
 
 from datetime import datetime
 
-# Enable use of markdown
-from recommonmark.parser import CommonMarkParser
-
-source_parsers = {
-    '.md': CommonMarkParser,
-}
-
 source_suffix = ['.rst', '.md']
-
-
-
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
+needs_sphinx = '1.8'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx_markdown_tables',
               'notfound.extension',
+              'recommonmark', # Enable use of markdown
               ]
 
 notfound_context = {


### PR DESCRIPTION
Changes the way "recommonmark" is loaded as explained in [recommonmark documentation](https://recommonmark.readthedocs.io/en/stable/#getting-started) for Sphinx `>= 1.4`. On the `requirements.txt` file we have that we need Sphinx `>= 1.8`, so I've also added that minimum requirement to the `conf.py`.