### PR TITLE
Include link to Zoom room scheduling

### DIFF
--- a/topic_folders/instructor_development/mentoring_groups.md
+++ b/topic_folders/instructor_development/mentoring_groups.md
@@ -149,7 +149,8 @@ To join the mentoring program as a mentee, complete [this form](https://docs.goo
 
 ##### Responsibilities
 
-- Decide on a meeting schedule with your Mentees.  
+- Decide on a meeting schedule with your Mentees.
+  - You can use a [Carpentries Zoom room](https://docs.carpentries.org/topic_folders/communications/tools/zoom_rooms.html) for your meetings - please reach out to team@carpentries.org for more information about scheduling a room. Details and links for meetings can be kept in a [Carpentries Etherpad](https://pad.carpentries.org). 
 - Personalise meetings based on Mentee’s needs and desires.  
 - Respond promptly to emails from your Mentees.  
 - Follow up with Mentees who miss meetings.  


### PR DESCRIPTION
Mentors may be interested in using the Carpentries Zoom rooms to communicate with mentees, and should know that resource is available to them