### PR TITLE
Adds today's date to the google calendar iframe link

### DIFF
--- a/topic_folders/communications/tools/zoom_rooms.md
+++ b/topic_folders/communications/tools/zoom_rooms.md
@@ -115,13 +115,16 @@ When done, click "ADD RESOURCE" and this new room should be on your list of room
 <script type="text/javascript">
   $(function(){
   var timezone = jstz.determine();
+  var today = new Date();
+  var str_date = today.getFullYear() + String(today.getMonth() + 1).padStart(2, '0') + String(today.getDate()).padStart(2, '0');
+  var date_link = '&dates=' + str_date + '/' + str_date;
   var frame_setup = '<iframe src="https://calendar.google.com/calendar/embed?title=The%20Carpentries%20Zoom%20Room%20Calendar&mode=DAY&'
   var rm1 = 'src=carpentries.org_31323339303138313831%40resource.calendar.google.com&color=%23711616&'
   var rm2 = 'src=carpentries.org_32323738323534333230@resource.calendar.google.com&color=%23BE6D00&'
   var rm3 = 'src=carpentries.org_393634313731303431@resource.calendar.google.com&color=%232F6309&'
   var tz_flag = 'ctz='
   var frame_close = '" style="border: 0" width="700" height="550" frameborder="0" scrolling="no"></iframe>'
-  var full_link =  frame_setup + rm1 + rm2 + rm3 + tz_flag + timezone.name() + frame_close;
+  var full_link =  frame_setup + rm1 + rm2 + rm3 + tz_flag + timezone.name() + str_date + frame_close;
   document.getElementById('zoom_calendar').innerHTML = full_link;
   // console.log(full_link); 
   });


### PR DESCRIPTION
Today I've jumped into a zoom room that was being used (:wave: @erjank). My problem was that the calendar on [our helping zoom page](https://docs.carpentries.org/topic_folders/communications/tools/zoom_rooms.html#zoom-manual) was showing yesterday's day, not today. 

For some reason, if set without the date the calendar shows the day before.
At least seen from London on a Monday at 18'00. The script detects properly my timezone and I've tried with various different calendars. Both, Chrome and Firefox show
the day before. Adding "today"'s date as a `dates` range to the URL seems to fix it (at
least locally on my machine).

I'm starting to believe it's a problem on the google side, but this change should not be disruptive in case they fix it.