### PR TITLE
Added *recommended* committee guidelines

### DIFF
--- a/topic_folders/governance/committee-guidelines.md
+++ b/topic_folders/governance/committee-guidelines.md
@@ -41,7 +41,7 @@ Each committee should have a public page with the following information:
 - __Name of incoming committee (co)-chair or vice-chair__
 - __Names of individuals in other committee roles__
 - __Executive Council Liaison__ 
-- __ Core Team Liaison__
+- __Core Team Liaison__
 - __Current committee members__  
 - __Information for how to join the committee__
 - __Past committee members__

--- a/topic_folders/governance/committee-guidelines.md
+++ b/topic_folders/governance/committee-guidelines.md
@@ -1,0 +1,57 @@
+# The Carpentries Committee Guidelines
+
+## Context
+Committees are an integral part of The Carpentries community. Establishing committee guidelines will ensure sustainability, reduce burnout, and ensure clear lines of communication and appropriate transparency for all Carpentries committees. The following guidelines are __recommendations__ to help committees establish guidelines, consistent documentation, and governance structure.
+
+## Committee Guidelines 
+
+To ensure sustainability, accountability and effective communication for our committees, we propose the following guidelines. Each committee should:
+
+- Hold regular meetings (at least 4 per year)  
+- Post meetings on the community calendar 
+   - Meetings do not necessarily need to be public. For the Code of Conduct Committee only business meetings are public, not incident meetings.  
+- Post meeting notes or minutes in a consistent location. Minutes can be public or private, depending on the committee.
+- Appoint a committee chair or co-chairs, with a description of their responsibilities
+- Identify a chair/co-chairs succession plan
+- Identify chair, and potentially committee, term limits
+- Include contact information for the committee
+- Host at least one community call per year
+- Provide a roles and responsibilities document for the committee 
+- Provide a short description of what the committee does
+- Provide a public list of current and past committee members
+- Identify processes for onboarding new members
+- Identify a process for offboarding members
+- Include a process for recruiting and selecting new members
+- Appoint a [core team member](https://carpentries.org/team/) liaison 
+- Appoint an Executive Council liaison 
+- Utilise The Carpentries [communication pathways](https://docs.carpentries.org/topic_folders/communications/index.html) 
+
+## Public Documentation
+Each committee should have a public page with the following information:
+
+- __Committee Name__  
+- __Short Committee Description__  
+- __Link to roles and responsibilities__   
+- __Link to committee materials: (e.g. the committee’s GitHub repo, and/or section of the handbook)__  
+- __Contact information for the committee__  
+- __Information for when meetings are held__  
+- __Link to meeting notes (current)__  
+- __Link to meeting notes (past)__  
+- __Name of committee (co)-chair__
+- __Name of incoming committee (co)-chair or vice-chair__
+- __Names of individuals in other committee roles__
+- __Executive Council Liaison__ 
+- __ Core Team Liaison__
+- __Current committee members__  
+- __Information for how to join the committee__
+- __Past committee members__
+
+## Internal Documentation  
+The committee should also have an internal document for the committee members that includes:
+
+- Link to onboarding information
+- Link to offboarding information
+- How the chair and other roles are selected
+- Information on recruiting or selecting committee members: e.g. language, rubric
+
+* These guidelines are __recommended__, not __required__.


### PR DESCRIPTION
Software Carpentry had guidance for committees, but when we merged into The Carpentries, we restructured to create both committees and Task Forces, and wanted to give some time to see how things came together before creating guidelines. We now have a workflow and Task Force Charter model, and want to work with the committees to establish guidelines and consistent documentation and structure for committees.

We are therefore adding these recommended committee guidelines to the handbook.