### PR TITLE
Remove Tracy's contact info from CoC reporting

### DIFF
--- a/topic_folders/policies/incident-reporting.md
+++ b/topic_folders/policies/incident-reporting.md
@@ -14,7 +14,6 @@ The Code of Conduct Committee takes all incident reports seriously and will revi
 
 If you would prefer other ways to contact us, an email to [coc@carpentries.org](mailto:coc@carpentries.org) will be seen by all of the [Code of Conduct committee](https://carpentries.org/coc-ctte). If you are uncomfortable reporting to the Code of Conduct committee, incidents can also be reported to Cam Macdonell, the designated ombudsman for The Carpentries, at [confidential@carpentries.org](mailto:confidential@carpentries.org).  
 
-The Carpentries Executive Director (Tracy Teal) can also be contacted by telephone at +1-530-341-3230 or email at [tkteal@carpentries.org](mailto:tkteal@carpentries.org).
 
 ##### Confidentiality
 

--- a/topic_folders/policies/incident-reporting.md
+++ b/topic_folders/policies/incident-reporting.md
@@ -14,6 +14,8 @@ The Code of Conduct Committee takes all incident reports seriously and will revi
 
 If you would prefer other ways to contact us, an email to [coc@carpentries.org](mailto:coc@carpentries.org) will be seen by all of the [Code of Conduct committee](https://carpentries.org/coc-ctte). If you are uncomfortable reporting to the Code of Conduct committee, incidents can also be reported to Cam Macdonell, the designated ombudsman for The Carpentries, at [confidential@carpentries.org](mailto:confidential@carpentries.org).  
 
+The Carpentries Acting Executive Director (Kari L. Jordan) can also be contacted by telephone at +1-407-476-6131 or email at [kariljordan@carpentries.org](mailto:kariljordan@carpentries.org).
+
 
 ##### Confidentiality
 


### PR DESCRIPTION
Not sure if this should be replaced temporarily with @kariljordan info, or wait until we have a new ED in place and they can decide on their role?