### PR TITLE
Update the Etherpad URL for community discussion

### DIFF
--- a/topic_folders/workshop_administration/email_templates.md
+++ b/topic_folders/workshop_administration/email_templates.md
@@ -251,7 +251,7 @@ Here are your pre and post survey response links for you to review.  As a remind
 
 For your convenience, below you will find several resources that are available to you as an instructor.  
 
-Weekly instructors discussion sessions where you can share your feedback and hear from other instructors. Feel free to join us whenever you are available. Check out the calendar here (http://pad.software-carpentry.org/instructor-discussion). Be sure to check your timezone when you sign up.
+Weekly instructors discussion sessions where you can share your feedback and hear from other instructors. Feel free to join us whenever you are available. Check out the calendar here (https://pad.carpentries.org/instructor-discussion). Be sure to check your timezone when you sign up.
 
 Data Carpentry (http://www.datacarpentry.org/blog/), Software Carpentry (https://software-carpentry.org/blog/), Library Carpentry (https://librarycarpentry.org/blog/) and The Carpentries (https://carpentries.org/blog/) also welcome blog posts from instructors and workshop hosts who share their experience conducting a workshop. You are more than welcome to contribute as well! If this is something that interests you, please let me know. 
 


### PR DESCRIPTION
It seems that the instructor discussion is now integrated as a part of community discussion, so changed the URL of the old instructor disctuttion Etherpad to the URL of community discussion Etherpad.

