### PR TITLE
Update executive-council.md

### DIFF
--- a/topic_folders/governance/executive-council.md
+++ b/topic_folders/governance/executive-council.md
@@ -5,12 +5,23 @@
 The Carpentries Executive Council is the highest leadership body of The Carpentries, to whom the Executive Director of 
 the Carpentries reports. The Council comprises nine members - four elected by the community and five appointed by the Executive Council. 
 
-The Executive Council is responsible for strategic and organisational planning, selecting the Executive Director and evaluating their performance, financial oversight, identifying revenue streams and resource development, approving and monitoring The Carpentries programs and services, and enhancing The Carpentries public image. Members of the Council also serve as advocates and ambassadors for the organisation, leveraging their networks to benefit the organization’s reputation and fundraising. The Executive Council executes these responsibilities through a combination of monthly Executive Council meetings and regular correspondence and collaboration via email and online platforms. For the full description of the Executive Council’s roles and responsibilities, see the Executive Council section of the [Carpentries Bylaws](bylaws.html#executive-council). 
+The Executive Council is responsible for strategic and organisational planning, selecting the Executive Director and evaluating their performance, financial oversight, identifying revenue streams and resource development, approving and monitoring The Carpentries programs and services, and enhancing The Carpentries public image. Members of the Council also serve as advocates and ambassadors for the organisation, leveraging their networks to benefit the organisation’s reputation and fundraising. The Executive Council executes these responsibilities through a combination of quarterly Executive Council meetings and regular correspondence and collaboration via email and online platforms. For the full description of the Executive Council’s roles and responsibilities, see the Executive Council section of the [Carpentries Bylaws](bylaws.html#executive-council). 
 
-In addition to [publicly posting meeting minutes](https://github.com/carpentries/executive-council-info/tree/master/minutes), the Executive Council reports on its activities periodically in [Carpentry Clippings](https://carpentries.org/newsletter/) (the organizational newsletter) as well as through [blog posts](https://carpentries.org/posts-by-tags/#blog-tag-governance).
-The council also prepares [Yearly Summaries](https://github.com/carpentries/executive-council-info/tree/master/year-in-review) of its activities.
+In addition to [publicly posting meeting minutes](https://github.com/carpentries/executive-council-info/tree/master/minutes), the Executive Council reports on its activities periodically in [Carpentries Clippings](https://carpentries.org/newsletter/) (the organisational newsletter) as well as through [blog posts](https://carpentries.org/posts-by-tags/#blog-tag-governance).
+The Council also prepares [Yearly Summaries](https://github.com/carpentries/executive-council-info/tree/master/year-in-review) of its activities.
 
-### Executive Council's Standing Committees
+### Executive Council Officers
+
+Executive Council officers are selected at the first regular meeting following election and appointment of new members and serve one year terms. Officer positions include:
+
+* Chair
+* Vice Chair
+* Secretary
+* Treasurer
+
+Roles and responsibilities for Executive Council Officers are described in the [bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#officers).
+
+### Executive Council Standing Committees
 As of January 2021, the following standing committee structure was implemented as a practical way to manage the work and engagement of the Executive Council:
 
 - [Officers Committee](#officers-committee)
@@ -20,99 +31,70 @@ As of January 2021, the following standing committee structure was implemented a
 
 Serving on a specific standing committee provides Executive Council members with the opportunity to bring their subject matter expertise to specific governance and operational priorities, deal with issues and projects more effectively and efficiently, and maximize time and resources between meetings. Each Executive Council member serves on at least one, but no more than two committees. When considered beneficial or necessary, these committees can have members from The Carpentries community and/or Core Team.
 
-In addition to the Standing committees, the Executive council may appoint Ad hoc committees to handle issues that are typically short-term and specialized in nature.
+In addition to the Standing committees, the Executive Council may appoint ad hoc committees to handle issues that are typically short-term and specialised in nature.
 
 #### Officers Committee
 This committee consists of the Executive Council Officers: Chair, Vice Chair, Secretary and Treasurer.
 
 **Roles & Responsibilities**
-- Act with full authority of the Executive Council between EC meetings when needed in urgent matters, subject to Executive Council imposed limitations on committee action
-Prioritize the agenda of the Executive Council meetings
-- Monitor the performance of the Executive Director, conduct their annual performance review, and make recommendations to the Executive Council regarding the Executive Director’s performance goals for the subsequent year
-- Provide a sounding board to the Executive Director and serve as a source of ready advice on operating and personnel matters
-- Obtain and evaluate relevant compensation information and make a recommendation to the Executive Council regarding the Executive Director’s compensation (including all benefits)
-- Provide support to the Executive Director and direction to the Executive Council on oversight of legal and operational issues
+- Act with full authority of the Executive Council between EC meetings when needed in urgent matters, subject to Executive Council imposed limitations on committee action either by ad hoc objection from any EC member or from a list of limitations specified in the bylaws. 
+- Prioritise the agenda of the Executive Council meetings. 
+- Monitor the performance of the Executive Director, conduct their annual performance review, and make recommendations to the Executive Council regarding the Executive Director’s performance goals for the subsequent year. 
+- Provide a sounding board to the Executive Director and serve as a source of ready advice on operating and personnel matters. 
+- Obtain and evaluate relevant compensation information and make a recommendation to the Executive Council regarding the Executive Director’s compensation (including all benefits). 
+- Provide support to the Executive Director and direction to the Executive Council on oversight of legal and operational issues. 
 - Lead Executive Council level oversight of the organization's long-term strategic plan and short-term annual planning, including annual review of strategic plan performance metrics against anticipated community end results (outcomes).
 
 #### Governance Committee
 This committee is chaired by the Vice Chair of the Executive Council.
 
 **Roles & Responsibilities**
-- Assess the Executive Council’s performance as the governing body of The Carpentries 
-- Lead the writing, maintenance, and updates to the Carpentries bylaws; revise/re-approve the bylaws every 2 years, or as needed, according to the bylaws
-- Lead the process to identify, nominate, and onboard new Executive Council members
-- Suggest special committees/task forces as needed and prepare for their formation as per the Committee Policy
+- Assess the Executive Council’s performance as the governing body of The Carpentries. 
+- Lead the writing, maintenance, and updates to the Carpentries bylaws; revise/re-approve the bylaws, as needed, according to the bylaws
+- Lead the process to identify, nominate, and onboard new Executive Council members.  
+- Suggest special committees/task forces as needed and prepare for their formation as per the [Committee Policy](https://docs.carpentries.org/topic_folders/governance/committee-policy.html#the-carpentries-committee-policy). 
+- Revise [Parliamentary Procedures for Executive Council Meetings](https://docs.google.com/document/d/1ywav0TY9F300lmQBFpsqQW4AR68H0-emkuImbG_2Mgs/edit#). 
+- Revise [The Carpentries Executive Council Elections: Timeline and Procedures](https://docs.google.com/document/d/1T_Smm8IOVVW3QUpOxYEFktebgup8vdxKPRY-TQOn1ho/edit#heading=h.97mnd6s3j6dc). 
 
 #### Finance Committee
 This committee is chaired by the Treasurer of the Executive Council.
 
 **Roles & Responsibilities**
-- Ensure strong fiduciary oversight and financial management
-- Make sure financial reports are accurate
-- Oversee the organization’s budget 
-- Identify revenue streams and resource development
-- Advise on a strategy to establish reserve funds, lines of credit, and short- and long-term investments
+- Ensuring strong fiduciary oversight and financial management. 
+- Making sure financial reports are accurate. 
+- Overseeing the organisation’s budget.  
+- Identifying revenue streams and resource development. 
+- Advise on a strategy for establishing reserve funds, lines of credit, and short- and long-term investments. 
 
 #### Program Committee
 This committee can be chaired by any member of the Executive Council.
 
 **Roles & Responsibilities**
-- Evaluate The Carpentries programs and services
-- Make recommendations to strengthen programs and services in line with the Carpentries mission, vision, and strategic plan
+- Approving and monitoring The Carpentries programs and services.
+- Make recommendations to strengthen programs and services in line with the Carpentries mission, vision, and strategic plan. 
 
 ### Contacting the Executive Council
-If you have a question or concern for the Executive Council,
-there are three ways for communicating with Executive Council Members:
+If you have a question or concern for the Executive Council, there are three ways to communicate with Executive Council Members:
 
 1. **File an [issue](https://github.com/carpentries/executive-council-info/issues) in this repository.** This is appropriate if you would like to solicit additional community feedback on a topic of general interest to the community.
 2. **Send us an [email](mailto:carpentries-executive-council@carpentries.org).** This is appropriate for communicating directly with the Executive Council but not the rest of our community.
 3. **Submit [this form](https://forms.gle/Adi54ESBi5hHmcdu5).** This is preferable if you would like confidential communication with the Executive Council, or if you would like to remain anonymous.
 
-### Executive Council's Documentation
+### Executive Council Documentation
 
-The information below describes all procedures, routines and resources
-relevant for the Executive Council.
-This information is added here as onboarding information
-for new Executive Council members,
-as well as to provide transparency for the community.
+The [Executive Council Handbook](https://docs.google.com/document/d/1QMw9rLhrWJardj-59tVr4JmpHH4o5O8O6i_73H2IKfo/edit) includes the following information:
 
-NOTE that a number of links lead to pages for which access is
-restricted to Executive Council members.
-We wish to be as transparent as we can,
-but sometimes we need to choose to withhold information from others.
-
-<!--From https://github.com/carpentries/executive-council-info/blob/master/process/roles_responsibilities.md]-->
-
-#### Responsibilities of all Executive Council Members
-
-The [Carpentries Bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#executive-council)
-describe the formal responsibilities of the Executive Council from an
-organisational level. This text describes the current implementation of the tasks described in the bylaws and represents
-flexible guidelines that may be adapted as the Executive Council deems necessary. In addition to documenting Executive Council standard operating
-procedures, it is also intended to clarify Executive Council function for the broader community and help potential members understand the
-commitment to serve on the Executive Council.
-
-In practice, each Executive Council member is responsible for the following general tasks:
-
-* Support the Mission and Vision of The Carpentries
-* Exemplify the Code of Conduct
-* Ensure The Carpentries’ adherence to legal agreements and standards
-* Offer their expertise to help ensure the health and success of the organization
-* Actively participate in discussions about strategic and financial decisions
-* Provide feedback and vote on formal motions within one week of their posting
-* Attend (in person or by phone/web-based) at least 75% of the meetings held each year
-* Dedicate at least three volunteer hours per week toward Carpentries activities (including meeting attendance)
-
-The specific commitments expected of Executive Council members include quarterly meetings (two hours, online) and a once-yearly
-face-to-face meeting (expenses covered by The Carpentries). Minutes for these meetings are published to [a GitHub repository](https://github.com/carpentries/executive-council-info/tree/master/minutes) after
-approval by Executive Council members. We may periodically schedule additional virtual meetings to address particular topics. Officers and Executive Council
-liaisons to Committees or Task Forces may have additional commitments for meetings. Asynchronous commitments involve suggesting
-agenda items for meetings, responding to email requests for opinions, and formal voting on resolutions (as issues in this
-repository), and work resulting from being on a task force or committee representing the Executive Council.
+- Roles and responsibilities of Executive Council Members
+- Onboarding documentation
+- Offboarding documentation
+- Communication and collaboration spaces
+- Step-by-step guides
+- Resources
+- Glossary of terms
 
 #### Executive Council transparency in decision making
 
-The Executive Council, the Core Team and the Executive Director [agreed](https://github.com/carpentries/executive-council-info/issues/61) on the following points:
+The Executive Council, the Core Team and the Executive Director [agreed](https://github.com/carpentries/executive-council-info/issues/61) on the following decision-making rubric:
 
 _1. The Executive Council should vote on:_
 
@@ -134,109 +116,9 @@ _3. The Executive Council should be informed of (but no decision or advising exp
 * Decisions relating to Core Team changes
 * The Executive Council needs to be generally informed where groups have explicit powers that affect the culture of the organisation (e.g. Decisions of the Lessons Programs governance committees and Task Forces)
 
+### Executive Council Meetings
 
-### Executive Council Officers
-
-Executive Council officers are selected at the first regular meeting following election and appointment of new members and serve one year
-terms. Officer positions include:
-
-* Chair
-* Vice Chair
-* Secretary
-* Treasurer
-
-General tasks for each officer position are described in
-[the bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#executive-council).
-More detailed descriptions can be found on the page describing the [Executive Council officers responsibilities](executive-council-officers.html).
-
-### Communication
-
-We use two mailing lists:
-
-* [executive-council@carpentries.org](mailto:executive-council@carpentries.org): this is an internal list, and includes Executive Council and Executive Director; this list can only receive messages from list members
-* [carpentries-executive-council@carpentries.org](mailto:carpentries-executive-council@carpentries.org): recipients are Executive Council Chair and Vice Chair; anyone can send to this, allowing the community to communicate directly with the Executive Council (but not the rest of our community)
-
-### Meetings
-
-The Executive Council generally meets once monthly (we are required to hold at least 10 meetings a year, either in person or online). Smaller groups of Executive Council members may hold additional meetings when needed.
-
-- [Publicly available meeting minutes](https://github.com/carpentries/executive-council-info/tree/master/minutes)
-- See the <u>Agendas and minutes</u> folder<sup>*</sup> in the Executive Council Google Drive. We use a single document for meeting agendas/minutes for the entire year (meetings from February - January)
-- Our <u>Meeting conduct</u> document<sup>*</sup> describes how we prepare for and conduct regular meetings, see the Google Doc in the above-mentioned folder (folder Agendas_Minutes --> Meeting conduct.gdoc)
-- Scheduling is done through our Google calendar<sup>*</sup>
-- Executive Council members are invited to attend the Core Team meetings whenever they desire
-
-### Finances and Fiscal Sponsor
-
-See the <u>Finance</u> folder<sup>*</sup> in the Executive Council Google Drive.
-
-#### The Carpentries Fiscal Sponsor
-
-The Carpentries is fiscally sponsored by [Community Initiatives](https://communityin.org/), a registered 501c3 based in Oakland, CA. Here are some relevant resources:
-
-*   [What is fiscal sponsorship?](https://communityin.org/fiscal-sponsorship/solving-problems-for-nonprofits/#fiscal-sponsorship)
-*   Who are CI's [other fiscally sponsored projects](https://communityin.org/our-projects/support-a-project/) (FSPs)?
-
-See also the Community Initiative's bylaws and the Carpentries’ fiscal sponsor agreement in the <u>Fiscal Sponsor</u> folder<sup>*</sup> on the Executive Council Google Drive (folder EC_processes --> folder Fiscal_Sponsor).
-
-
-### GitHub
-
-We maintain multiple repositories with variable permissions (some public, some restricted to Executive Council and/or various Core Team members).
-
-#### Under https://github.com/carpentries
-
-This is a GitHub organisation 'owned' by The Carpentries Core Team. Executive council members have access, as well as members of the Core Team and some community members
-
-<https://github.com/carpentries/executive-council-info>
-
-* *public* repository
-* used to publish information intended for the community, such as our monthly meeting minutes
-* also used for voting on our our motions (our decisions)
-
-<https://github.com/carpentries/executive-council><sup>*</sup>
-
-* *private* repository
-* used for discussions between Executive Council and Executive Director that require broader direct feedback from the Core Team
-* issues for approval of meeting minutes are posted here
-
-#### Under https://github.com/carpentries-ec
-
-This is a GitHub organisation 'owned' by the Executive Council, used for information or documents that *only* Executive Council members should have access to. Optionally, the Executive Director can be given access by inviting them as collaborator.
-
-<https://github.com/carpentries-ec/conversations_ec_ed><sup>*</sup>
-
-* *private* repository. Executive council members have access, as well as the Executive Director (but not the Core Team)
-* used to
-  * discuss issues between Executive Council and Executive Director outside of the Executive Council monthly meetings
-  * storing relevant information that needs to be private to the world, and necessary or OK for the Executive Director to have access to
-
-
-<https://github.com/carpentries-ec/minutes-private><sup>*</sup>
-
-* *private* repository, *only Executive Council* (not Executive Director or the Core Team) have access
-* used for
-  * those parts of the minutes that only Executive Council should have access to
-  * voting on motions that should only be visible to Executive Council.
-    Examples of such discussions and motions:
-    * hiring of a new Executive Director
-    * salary discussions/decisions
-
-<https://github.com/carpentries-ec/financeviz><sup>*</sup>
-
-* *private* repository, Executive Council, Executive Director and the Core Team have access
-* used for visualisations and plots for communicating The Carpentries finances
-
-### Google Drive
-
-We use a private Google Drive folder called <u>Carpentries_Executive_Council</u><sup>*</sup>, see its README for orientation to contents.
-
-### Quarterly Executive Council Meetings
-
-<!--From https://github.com/carpentries/executive-council-info/blob/master/process/timeline.md]-->
-
-Recurring agenda items for each meeting
-(Each meeting can, and probably will, have additional agenda items)
+The Executive Council meets quarterly (i.e. February, May, August, December). Standing Committees hold additional meetings when needed, typically monthly. Minutes of the Executive Council meetings are shared publically in the [executive-council-info repository](https://github.com/carpentries/executive-council-info/tree/master/minutes). Executive Council members are invited to attend the Core Team meetings as needed, and Core Team members attend Standing Committee meetings as needed. A list of issues to be discussed during quarterly Executive Council meetings is provided below. A monthly list of issues to be discussed and tasks to complete outside of quarterly Executive Council meetings is provided in the [Executive Council Work Plan](https://github.com/carpentries/executive-council-info/blob/main/process/workplan.md)
 
 #### February
 * Approve minutes from December meeting
@@ -251,7 +133,6 @@ Recurring agenda items for each meeting
 * Standing Committee Reports
 * Review draft of annual financial report
 * Review and discussion of strategic plan activities
-* 2022: Approve Election Policy
 
 #### August
 * Approve minutes from May meeting
@@ -261,132 +142,9 @@ Recurring agenda items for each meeting
 * Identify desired skills for incoming Executive Council members
 
 #### December
-* Approve minutes from September meeting
-* Election of the next Executive Council (done at the Q4 meeting) 
-* Election of council-elected members
-* Ratifying community-elected members and council-elected members
-* Ratifying the new Executive Council composition
-* Approve Bylaws amendments, if any (even-numbered years only)
+* Approve minutes from August meeting
+* Election of the next Executive Council 
 * Review Q3 financial report
 * Approve next year’s budget
 * Standing Committee Reports
 * Review and discussion of strategic plan activities
-
-### Calendar of Events
-Timeline of issues to be resolved outside of meetings
-
-#### January
-* Publish Q4 Code of Conduct Transparency Report
-* Review previous years’ minutes, ensuring all are approved and posted
-* Finish logistics of offboarding outgoing members and onboarding incoming members
-* Assess availability of incoming Executive Council members for an in-person meeting at onboarding
-
-#### February
-* New Executive Council officially takes over
-
-#### April
-* Publish Q1 Code of Conduct Transparency Report
-
-#### July
-* Publish Q2 Code of Conduct Transparency Report
-
-#### August
-* Solicit nominations for council-elected members
-
-#### October
-* Announce opening of self-nomination for Executive Council
-* Publish Q3 Code of Conduct Transparency Report
-
-#### November
-* Nominations for Executive Council Elections close
-* Start Executive Director Performance Evaluation
-
-#### December
-* Community elections open first full week (Monday - Friday)
-* Finish Executive Director Performance Evaluation
-* Announcement of the new Executive Council
-* Start logistics of offboarding outgoing members and onboarding incoming members
-* Start organising dates for face-to-face meetings in first half of the year
-
-#### Additional annual tasks:
-
-* in-person (face-to-face) meeting
-* reassessing the strategic plan
-* annual financial report
-
-#### Additional recurring tasks:
-
-* every second year, starting 2020: revision or reapproval of the bylaws
-
-### Elections
-
-Details about how Executive Council Members are elected and their terms of service are available in the [bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#nominations-and-elections). Elections are currently administered by an Executive Council Member (who is not up for re-election) via [ElectionBuddy](https://electionbuddy.com).
-
-A checklist for the Executive Council election process is available as a <u>Google Doc</u><sup>*</sup> in the Executive Council Google Drive (folder Election --> EC Election Process.gdoc)
-
-An overview of whose council member's seats are up for (re-)election
-can be found in a <u>Google Sheet</u><sup>*</sup> (folder Elections --> Year-of-term for executive council members.gsheet).
-
-### Transitions between Executive Councils
-
-<!--From https://github.com/carpentries/executive-council-info/blob/master/process/EC_transition.md]-->
-
-The transfer of responsibilities to the incoming Executive Council includes
-
-* [onboarding new members to Executive Council processes](#onboarding-new-executive-council-members)
-* [updating access to resources](#access-to-resources)
-* [selecting members to serve in specific roles](#transfer-of-member-responsibilities)
-
-A checklist for the transition process can be found as a <u>Google Doc</u><sup>*</sup> (folder EC_processes --> Onboarding_offboarding members, ED.gdoc).
-
-
-#### Onboarding new Executive Council members
-
-New (incoming) members (both Community-elected and Council-elected) are announced in late December/early January. The official term of office for incoming Executive Council members is February 1. We ask that incoming members attend the final regularly scheduled meeting of the current Executive Council in January,
-prior to taking office, to learn how meetings operate, and to prepare for formal transfer of responsibility.
-
-The outgoing Chair and/or Vice Chair should meet with the incoming Executive Council members and Executive Director in January to discuss the following key points:
-
-* The general workflow of the Executive Council
-  * monthly meetings
-  * as-needed special meetings and yearly in-person meeting
-  * asynchronous communications
-* Where different types of information are stored
-* Responsibilities and expectations for all Executive Council members
-
-#### Access to resources
-
-Executive Council members have access to the following resources:
-
-* Google Drive folder <u>Carpentries_Executive_Council</u>
-* GitHub organisations, teams, and repositories
-  * Organisation: carpentries
-    * Team: carpentries/executive-council
-    * Repo: executive-council-info (public, this repository)
-  * Repo: private (Executive Council + the Core Team)
-    * Team: carpentries-ec/ec
-    * Repo: Executive Council + Executive Director
-    * Repo: Executive Council only
-* Mailing list (listserv)
-  - executive-council@carpentries.org
-* Executive Council Google Calendar
-
-Incoming Executive Council members should be granted access to these resources in January. Outgoing members' access to these resources should be removed in February.
-
-Additionally, The Carpentries' website that includes the [Executive Council Members/Officers](http://static.carpentries.org/governance/) should be updated.
-
-#### Transfer of member responsibilities
-
-The following Executive Council roles should be assigned at the February meeting (these require formal voting by Executive Council members):
-
-* Officer positions:
-  * Chair
-  * Vice Chair
-  * Secretary
-  * Treasurer
-* Committee representatives (these may continue from previous terms as applicable):
-  * 2 x 2 Committee representatives
-  * CoC representative
-  * Representatives to Community Initiatives (CI)
-
-<sup>*</sup>Access to this information is restricted to Executive Council members.


### PR DESCRIPTION
This pull request streamlines the Executive Council (non-bylaws) section of the handbook by:

- Linking to the Google Docs version of the EC handbook (updated periodically and uses the new handbook format developed by CDT)
- Removes information that has been duplicated in the handbook
- Uses consistent spelling per our style guide

As this does not change the bylaws, it does not need approval and is ready to be merged.